### PR TITLE
update windows build info

### DIFF
--- a/work/win32/Makefile.win32
+++ b/work/win32/Makefile.win32
@@ -13,15 +13,15 @@
 # General Public License along with Libmarpa.  If not, see
 # http://www.gnu.org/licenses/.
 
-# Build static and dynamic libraries of Marpa, using a config.h generated with Marpa::R2::Build_Me
+# Build static and dynamic libraries of Marpa, using a config.h generated with
+# Marpa::R2::Build_Me
 
-# IMPORTANT!!!  MARPA HAS BEEN REFACTORED AND THIS SCRIPT WILL NO LONGER WORK.
-# Libmarpa has been split into a separate repository, and the directory
-# structures have changed
-
+# You should make sure that you have fairly recent: MSVC, perl,
+# Config::AutoConf, and execute this Makefile as follows after
+# changing to this directory in a command shell where all MSVC
+# environment variables are set:
 #
-# You should execute this Makefile in the ??? directory like this:
-# nmake -f Makefile.win32
+# 	set /p MARPA_VERSION= <LIB_VERSION & nmake -fMakefile.win32
 #
 
 CC = cl


### PR DESCRIPTION
Once the dist is built as per INSTALL, it can be unpacked on a windows machine and Makefile.win32 can be used as described in this commit to build static and shared libmarpa, as I was pleased to know.

Also, if that's not too difficult, providing a recent pre-built libmarpa-7.5.0.tar.gz for downloading from [releases](https://github.com/jeffreykegler/libmarpa/releases) seems to be a good idea.