### PR TITLE
fix warning: implicit declaration of function ‘sprintf’

### DIFF
--- a/work/public/marpa.h.p10
+++ b/work/public/marpa.h.p10
@@ -3,6 +3,7 @@
 #ifndef _MARPA_H__
 #define _MARPA_H__ 1
 
+#include "stdio.h"
 #include "stdlib.h"
 #include "stddef.h"
 #include "string.h"


### PR DESCRIPTION
this one fixes the below warnings caught by gcc 4.92 under cygwin
```
marpa.w:16034:1: warning: implicit declaration of function ‘sprintf’ [-Wimplicit-function-declaration]
marpa.w:16034:1: warning: incompatible implicit declaration of built-in function ‘sprintf’
marpa.w: In function ‘lim_tag_safe’:
marpa.w:16059:1: warning: incompatible implicit declaration of built-in function ‘sprintf’
marpa.w: In function ‘or_tag_safe’:
marpa.w:16087:1: warning: incompatible implicit declaration of built-in function ‘sprintf’
marpa.w:16118:1: warning: incompatible implicit declaration of built-in function ‘sprintf’
marpa.w:16120:1: warning: incompatible implicit declaration of built-in function ‘sprintf’
```