### PR TITLE
Methods from 11.5 rules on trivial grammar

### DIFF
--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -152,8 +152,8 @@ main (int argc, char *argv[])
   ((R_C2_3 = marpa_g_rule_new (g, S_C2, rhs, 0)) >= 0)
     || fail ("marpa_g_rule_new", g);
   
-  /* this must hard fail as the start symbol is not set */
-  is_int(-2, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start() before marpa_g_start_symbol_set()");
+  /* this must soft fail if there is not start symbol */
+  is_int(-1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start() before marpa_g_start_symbol_set()");
   is_int(-1, marpa_g_start_symbol (g), "marpa_g_start_symbol() before marpa_g_start_symbol_set()");
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -92,7 +92,7 @@ main (int argc, char *argv[])
   /* Longest rule is <= 4 symbols */
   Marpa_Symbol_ID rhs[4];
 
-  plan(3);
+  plan(11);
 
   marpa_c_init (&marpa_configuration);
   g = marpa_g_new (&marpa_configuration);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -87,7 +87,7 @@ main (int argc, char *argv[])
   Marpa_Rule_ID R_top_2;
   Marpa_Rule_ID R_C2_3; // highest rule id
 
-  plan(30);
+  plan(31);
 
   marpa_c_init (&marpa_configuration);
   g = marpa_g_new (&marpa_configuration);
@@ -151,6 +151,10 @@ main (int argc, char *argv[])
 
   ((R_C2_3 = marpa_g_rule_new (g, S_C2, rhs, 0)) >= 0)
     || fail ("marpa_g_rule_new", g);
+  
+  /* this must hard fail as the start symbol is not set */
+  is_int(-2, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start() before marpa_g_start_symbol_set()");
+  is_int(-2, marpa_g_start_symbol (g), "marpa_g_start_symbol() before marpa_g_start_symbol_set()");
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
@@ -165,13 +169,12 @@ main (int argc, char *argv[])
   is_int(-2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable() before marpa_g_precompute()");
   is_int(-2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()  before marpa_g_precompute()");
   is_int(-2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive() before marpa_g_precompute()");
-  is_int(-2, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start() before marpa_g_precompute()");
   is_int(-2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal() before marpa_g_precompute()");
   /* Rules */
   is_int(-2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable() before marpa_g_precompute()");
   is_int(-2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling() before marpa_g_precompute()");
   is_int(-2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop() before marpa_g_precompute()");
-
+  
   if (marpa_g_precompute (g) < 0)
     {
       marpa_g_error (g, &error_string);
@@ -199,9 +202,9 @@ main (int argc, char *argv[])
   is_int(1, marpa_g_rule_is_productive (g, R_C2_3), "marpa_g_rule_is_productive()");
   is_int(1, marpa_g_rule_length (g, R_top_1), "marpa_g_rule_length(), rule R_top_1");
   is_int(0, marpa_g_rule_length (g, R_C2_3), "marpa_g_rule_length(), rule R_C2_3");
-  is_int(S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs (), rule R_top_1");
-  is_int(S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs (), rule R_top_1");
-  is_int(S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs (), rule R_top_2");
+  is_int(S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs(), rule R_top_1");
+  is_int(S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs(), rule R_top_1");
+  is_int(S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs(), rule R_top_2");
 
   /* recognizer methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -171,18 +171,16 @@ main (int argc, char *argv[])
     }
   ok(1, "precomputation succeeded");
 
-  /* 
-   * grammar methods 
-   */
+  /* grammar methods */
 
-  /* these do have @<Fail if not precomputed@>@ */
+  /* 11.4 Symbols -- these do have @<Fail if not precomputed@>@ */
   is_int(1, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible()");
   is_int(1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
   is_int(1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
   is_int(1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
   is_int(1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
-
+  
   /* recognizer methods */
   r = marpa_r_new (g);
   if (!r)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -83,11 +83,11 @@ main (int argc, char *argv[])
   /* Longest rule is <= 4 symbols */
   Marpa_Symbol_ID rhs[4];
 
-  Marpa_Rule_ID R_A1_1;
-  Marpa_Rule_ID R_A1_2;
+  Marpa_Rule_ID R_top_1;
+  Marpa_Rule_ID R_top_2;
   Marpa_Rule_ID R_C2_3; // highest rule id
 
-  plan(12);
+  plan(30);
 
   marpa_c_init (&marpa_configuration);
   g = marpa_g_new (&marpa_configuration);
@@ -129,10 +129,10 @@ main (int argc, char *argv[])
     || fail ("marpa_g_symbol_is_nulled_event_set", g);
 
   rhs[0] = S_A1;
-  ((R_A1_1 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
+  ((R_top_1 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
     || fail ("marpa_g_rule_new", g);
   rhs[0] = S_A2;
-  ((R_A1_2 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
+  ((R_top_2 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
     || fail ("marpa_g_rule_new", g);
   rhs[0] = S_B1;
   (marpa_g_rule_new (g, S_A1, rhs, 1) >= 0)
@@ -167,9 +167,9 @@ main (int argc, char *argv[])
     }
   ok(1, "precomputation succeeded");
 
-  /* grammar methods */
+  /* grammar methods, per sections of api.texi's Grammar Methods */
 
-  /* 11.4 Symbols -- these do have @<Fail if not precomputed@>@ */
+  /* Symbols -- these do have @<Fail if not precomputed@>@ */
   is_int(1, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible()");
   is_int(1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
   is_int(1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
@@ -177,9 +177,18 @@ main (int argc, char *argv[])
   is_int(1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
   
-  /* 11.5 Rules */
-  is_int(R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id ()");
-  is_int(1, marpa_g_rule_is_accessible (g, R_A1_1), "marpa_g_rule_is_accessible()");
+  /* Rules */
+  is_int(R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id()");
+  is_int(1, marpa_g_rule_is_accessible (g, R_top_1), "marpa_g_rule_is_accessible()");
+  is_int(1, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable()");
+  is_int(1, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling()");
+  is_int(0, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop()");
+  is_int(1, marpa_g_rule_is_productive (g, R_C2_3), "marpa_g_rule_is_productive()");
+  is_int(1, marpa_g_rule_length (g, R_top_1), "marpa_g_rule_length(), rule R_top_1");
+  is_int(0, marpa_g_rule_length (g, R_C2_3), "marpa_g_rule_length(), rule R_C2_3");
+  is_int(S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs (), rule R_top_1");
+  is_int(S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs (), rule R_top_1");
+  is_int(S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs (), rule R_top_2");
 
   /* recognizer methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -85,6 +85,8 @@ main (int argc, char *argv[])
   const char *error_string;
   struct stat sb;
 
+  int highest_rule_id;
+
   Marpa_Config marpa_configuration;
 
   Marpa_Grammar g;
@@ -153,7 +155,9 @@ main (int argc, char *argv[])
     || fail ("marpa_g_rule_new", g);
   (marpa_g_rule_new (g, S_C1, rhs, 0) >= 0)
     || fail ("marpa_g_rule_new", g);
-  (marpa_g_rule_new (g, S_C2, rhs, 0) >= 0)
+
+  highest_rule_id = marpa_g_rule_new (g, S_C2, rhs, 0);
+  (highest_rule_id >= 0)
     || fail ("marpa_g_rule_new", g);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
@@ -181,6 +185,9 @@ main (int argc, char *argv[])
   is_int(1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
   
+  /* 11.5 Rules */
+  is_int(highest_rule_id, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id ()");
+
   /* recognizer methods */
   r = marpa_r_new (g);
   if (!r)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -155,9 +155,22 @@ main (int argc, char *argv[])
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
-  /* these don't have @<Fail if not precomputed@>@, but just in case */
+  /* these don't have @<Fail if not precomputed@>@ and must succeed */
   is_int(S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
   is_int(S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
+  
+  /* these must return -2 as the grammar is not precomputed */
+  /* Symbols */
+  is_int(-2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible() before marpa_g_precompute()");
+  is_int(-2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable() before marpa_g_precompute()");
+  is_int(-2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()  before marpa_g_precompute()");
+  is_int(-2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive() before marpa_g_precompute()");
+  is_int(-2, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start() before marpa_g_precompute()");
+  is_int(-2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal() before marpa_g_precompute()");
+  /* Rules */
+  is_int(-2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable() before marpa_g_precompute()");
+  is_int(-2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling() before marpa_g_precompute()");
+  is_int(-2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop() before marpa_g_precompute()");
 
   if (marpa_g_precompute (g) < 0)
     {

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -180,11 +180,7 @@ main (int argc, char *argv[])
   is_int(1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
   is_int(1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
   is_int(1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
-  
-  rc = marpa_g_symbol_is_start (g, S_top);
-  ok(rc >= 0, "marpa_g_symbol_is_start() call successful");
-  is_int(1, rc, "marpa_g_symbol_is_start(g, S_top) return value");
-  
+  is_int(1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
 
   /* recognizer methods */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -83,7 +83,11 @@ main (int argc, char *argv[])
   /* Longest rule is <= 4 symbols */
   Marpa_Symbol_ID rhs[4];
 
-  plan(11);
+  Marpa_Rule_ID R_A1_1;
+  Marpa_Rule_ID R_A1_2;
+  Marpa_Rule_ID R_C2_3; // highest rule id
+
+  plan(12);
 
   marpa_c_init (&marpa_configuration);
   g = marpa_g_new (&marpa_configuration);
@@ -125,10 +129,10 @@ main (int argc, char *argv[])
     || fail ("marpa_g_symbol_is_nulled_event_set", g);
 
   rhs[0] = S_A1;
-  (marpa_g_rule_new (g, S_top, rhs, 1) >= 0)
+  ((R_A1_1 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
     || fail ("marpa_g_rule_new", g);
   rhs[0] = S_A2;
-  (marpa_g_rule_new (g, S_top, rhs, 1) >= 0)
+  ((R_A1_2 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
     || fail ("marpa_g_rule_new", g);
   rhs[0] = S_B1;
   (marpa_g_rule_new (g, S_A1, rhs, 1) >= 0)
@@ -145,8 +149,7 @@ main (int argc, char *argv[])
   (marpa_g_rule_new (g, S_C1, rhs, 0) >= 0)
     || fail ("marpa_g_rule_new", g);
 
-  highest_rule_id = marpa_g_rule_new (g, S_C2, rhs, 0);
-  (highest_rule_id >= 0)
+  ((R_C2_3 = marpa_g_rule_new (g, S_C2, rhs, 0)) >= 0)
     || fail ("marpa_g_rule_new", g);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
@@ -175,7 +178,8 @@ main (int argc, char *argv[])
   is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
   
   /* 11.5 Rules */
-  is_int(highest_rule_id, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id ()");
+  is_int(R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id ()");
+  is_int(1, marpa_g_rule_is_accessible (g, R_A1_1), "marpa_g_rule_is_accessible()");
 
   /* recognizer methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -99,7 +99,7 @@ main (int argc, char *argv[])
   if (!g)
     {
       Marpa_Error_Code errcode =
-	marpa_c_error (&marpa_configuration, &error_string);
+      marpa_c_error (&marpa_configuration, &error_string);
       printf ("marpa_g_new returned %d: %s", errcode, error_string);
       exit (1);
     }
@@ -159,9 +159,9 @@ main (int argc, char *argv[])
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
-	/* these don't have @<Fail if not precomputed@>@, but just in case */
-	is_int(S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
-	is_int(S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()");	
+  /* these don't have @<Fail if not precomputed@>@, but just in case */
+  is_int(S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
+  is_int(S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
 
   if (marpa_g_precompute (g) < 0)
     {
@@ -171,23 +171,23 @@ main (int argc, char *argv[])
     }
   ok(1, "precomputation succeeded");
 
-	/* 
-	 * grammar methods 
-	 */
+  /* 
+   * grammar methods 
+   */
 
-	/* these do have @<Fail if not precomputed@>@ */
-	is_int(1, marpa_g_symbol_is_accessible	(g, S_C2), "marpa_g_symbol_is_accessible()");
-	is_int(1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
-	is_int(1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
-	is_int(1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
-	
-	rc = marpa_g_symbol_is_start (g, S_top);
-	ok(rc >= 0, "marpa_g_symbol_is_start() call successful");
-	is_int(1, rc, "marpa_g_symbol_is_start() return value");
-	
-	is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
+  /* these do have @<Fail if not precomputed@>@ */
+  is_int(1, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible()");
+  is_int(1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
+  is_int(1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
+  is_int(1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
+  
+  rc = marpa_g_symbol_is_start (g, S_top);
+  ok(rc >= 0, "marpa_g_symbol_is_start() call successful");
+  is_int(1, rc, "marpa_g_symbol_is_start(g, S_top) return value");
+  
+  is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
 
-	/* recognizer methods */
+  /* recognizer methods */
   r = marpa_r_new (g);
   if (!r)
     {
@@ -203,6 +203,6 @@ main (int argc, char *argv[])
       exit (1);
     }
   ok((marpa_r_is_exhausted(r)), "exhausted at earleme 0");
-	
+  
   return 0;
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -154,7 +154,7 @@ main (int argc, char *argv[])
   
   /* this must hard fail as the start symbol is not set */
   is_int(-2, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start() before marpa_g_start_symbol_set()");
-  is_int(-2, marpa_g_start_symbol (g), "marpa_g_start_symbol() before marpa_g_start_symbol_set()");
+  is_int(-1, marpa_g_start_symbol (g), "marpa_g_start_symbol() before marpa_g_start_symbol_set()");
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -17,13 +17,7 @@
 
 /* Tests of Libmarpa methods on trivial grammar */
 
-#include <stdlib.h>
-#include <unistd.h>
 #include <stdio.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <fcntl.h>
-#include <sys/mman.h>
 #include "marpa.h"
 
 #include "tap/basic.h"
@@ -79,13 +73,8 @@ is_nullable (Marpa_Symbol_ID id)
 int
 main (int argc, char *argv[])
 {
-  const unsigned char *p, *eof;
-  int i;
   int rc;
   const char *error_string;
-  struct stat sb;
-
-  int highest_rule_id;
 
   Marpa_Config marpa_configuration;
 


### PR DESCRIPTION
This PR adds tests for methods in 11.5 Rules of api.texi, which all pass after `marpa_g_precompute()`.

Test failures (not directly related to trivial grammars):

`marpa_g_symbol_is_start(g, S_top)` returns 0 before `marpa_g_start_symbol_set()` -- I'd expect a soft failure, akin to `marpa_g_start_symbol()` .

`marpa_g_symbol_is_terminal()`, `marpa_g_rule_is_nullable()`, and `marpa_g_rule_is_nulling()` return 0 (not -2 as the doc says) before `marpa_g_precompute()` -- not sure if this a doc bug or a code bug or a feature.
