### PR TITLE
Follow up on 11.4 symbols

### DIFF
--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -43,8 +43,8 @@ Marpa_Symbol_ID S_B2;
 Marpa_Symbol_ID S_C1;
 Marpa_Symbol_ID S_C2;
 
-/* For fatal error messages */
-char error_buffer[80];
+/* For (error) messages */
+char msgbuf[80];
 
 char *
 symbol_name (Marpa_Symbol_ID id)
@@ -56,9 +56,9 @@ symbol_name (Marpa_Symbol_ID id)
   if (id == S_B2) return "B2";
   if (id == S_C1) return "C1";
   if (id == S_C2) return "C2";
-  sprintf (error_buffer, "no such symbol: %d", id);
-  return error_buffer;
-};
+  sprintf (msgbuf, "no such symbol: %d", id);
+  return msgbuf;
+}
 
 int
 is_nullable (Marpa_Symbol_ID id)
@@ -71,8 +71,23 @@ is_nullable (Marpa_Symbol_ID id)
   if (id == S_C1) return 1;
   if (id == S_C2) return 1;
   return 0;
-};
+}
 
+/* test retcode and error code on expected failure */
+static int
+is_failure(Marpa_Grammar g, Marpa_Error_Code wanted, int retcode, char *method_name, char *msg)
+{
+}
+
+/* test retval and print error code on unexpected failure */
+static int
+is_success(Marpa_Grammar g, int wanted, int retval, char *method_name, char *msg)
+{
+  sprintf (msgbuf, "%s(), %s", method_name, msg);
+  is_int(wanted, retval, msgbuf);
+  if (retval < 0)
+    warn(method_name, g);
+}
 
 int
 main (int argc, char *argv[])
@@ -202,12 +217,13 @@ main (int argc, char *argv[])
   is_int(0, marpa_g_rule_length (g, R_C2_3), "marpa_g_rule_length(), rule R_C2_3");
   is_int(S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs(), rule R_top_1");
   is_int(S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs(), rule R_top_1");
-  is_int(S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs(), rule R_top_2");
+  is_success(g, S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs", "rule R_top_2");
 
   /* recognizer methods */
   r = marpa_r_new (g);
   if (!r) 
     fail("marpa_r_new", g);
+
   rc = marpa_r_start_input (r);
   if (!rc)
     fail("marpa_r_start_input", g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -189,9 +189,9 @@ main (int argc, char *argv[])
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
-  /* these don't have @<Fail if not precomputed@>@ and must succeed */
-  is_int(S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
-  is_int(S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
+  /* these must succeed after the start symbol is set */
+  is_success(g, S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
+  is_success(g, S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
   
   /* these must return -2 and set error code to MARPA_ERR_NOT_PRECOMPUTED */
   /* Symbols */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -242,7 +242,8 @@ main (int argc, char *argv[])
   if (!rc)
     fail("marpa_r_start_input", g);
 
-  ok((marpa_r_is_exhausted(r)), "exhausted at earleme 0");
+  diag ("at earleme 0");
+  is_success(g, 1, marpa_r_is_exhausted(r), "marpa_r_is_exhausted()");
   
   return 0;
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -242,13 +242,6 @@ main (int argc, char *argv[])
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
-  /* set start as terminal */  
-  is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_top, 1), 
-    "marpa_g_symbol_is_terminal_set()");
-  /* set nullable symbol as terminal */
-  is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_A1, 1), 
-    "marpa_g_symbol_is_terminal_set()");
-  
   if (marpa_g_precompute (g) < 0)
     fail("marpa_g_precompute", g);
   ok(1, "precomputation succeeded");

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -231,15 +231,23 @@ main (int argc, char *argv[])
   is_failure(g, MARPA_ERR_TERMINAL_IS_LOCKED, -2, marpa_g_symbol_is_terminal_set(g, S_C1, 0), 
     "marpa_g_symbol_is_terminal_set", "on a symbol already set to be a terminal");
   is_failure(g, MARPA_ERR_NULLING_TERMINAL, -2, marpa_g_precompute (g), "marpa_g_precompute", "with a nulling terminal");
+  
+  /* terminals are locked after setting, so we recreate the grammar */
+  marpa_g_unref(g);
+  g = trivial_grammar(&marpa_configuration);
+  
+  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -2, marpa_g_precompute (g), "marpa_g_precompute", "with a nulling terminal");
+
+  /* set start symbol */
+  (marpa_g_start_symbol_set (g, S_top) >= 0)
+    || fail ("marpa_g_start_symbol_set", g);
+
   /* set start as terminal */  
   is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_top, 1), 
     "marpa_g_symbol_is_terminal_set()");
-  /* set nulable symbol as terminal */
+  /* set nullable symbol as terminal */
   is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_A1, 1), 
     "marpa_g_symbol_is_terminal_set()");
-  
-  /* terminals are locked after as */
-  marpa_g_unref(g);
   
   if (marpa_g_precompute (g) < 0)
     fail("marpa_g_precompute", g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -22,8 +22,6 @@
 
 #include "tap/basic.h"
 
-#define TESTS 33
-
 static int
 warn (const char *s, Marpa_Grammar g)
 {
@@ -120,7 +118,7 @@ main (int argc, char *argv[])
   Marpa_Rule_ID R_top_2;
   Marpa_Rule_ID R_C2_3; // highest rule id
 
-  plan(TESTS);
+  plan_lazy();
 
   marpa_c_init (&marpa_configuration);
   g = marpa_g_new (&marpa_configuration);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -183,8 +183,9 @@ main (int argc, char *argv[])
     || fail ("marpa_g_rule_new", g);
   
   /* this must soft fail if there is not start symbol */
-  is_failure(g, 43, -1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start", "before marpa_g_start_symbol_set()");
-  is_failure(g, 43, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", "before marpa_g_start_symbol_set()");
+#define NO_START_TEST_MSG "fail before marpa_g_start_symbol_set()"
+  is_failure(g, 43, -1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start", NO_START_TEST_MSG);
+  is_failure(g, 43, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", NO_START_TEST_MSG);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
@@ -193,17 +194,18 @@ main (int argc, char *argv[])
   is_int(S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
   is_int(S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
   
-  /* these must return -2 as the grammar is not precomputed */
+  /* these must return -2 and set error code to MARPA_ERR_NOT_PRECOMPUTED */
   /* Symbols */
-  is_int(-2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible() before marpa_g_precompute()");
-  is_int(-2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable() before marpa_g_precompute()");
-  is_int(-2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()  before marpa_g_precompute()");
-  is_int(-2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive() before marpa_g_precompute()");
-  is_int(-2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal() before marpa_g_precompute()");
+#define NOT_PRECOMPUTED_TEST_MSG "fail before marpa_g_precompute()"  
+  is_failure(g, 34, -2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, 34, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, 34, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, 34, -2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, 34, -2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal", NOT_PRECOMPUTED_TEST_MSG);
   /* Rules */
-  is_int(-2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable() before marpa_g_precompute()");
-  is_int(-2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling() before marpa_g_precompute()");
-  is_int(-2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop() before marpa_g_precompute()");
+  is_failure(g, 34, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, 34, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, 34, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", NOT_PRECOMPUTED_TEST_MSG);
   
   if (marpa_g_precompute (g) < 0)
     fail("marpa_g_precompute", g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -91,10 +91,9 @@ is_failure(Marpa_Grammar g, Marpa_Error_Code errcode_wanted, int retcode_wanted,
 
 /* test retval and print error code on unexpected failure */
 static int
-is_success(Marpa_Grammar g, int wanted, int retval, char *method_name, char *msg)
+is_success(Marpa_Grammar g, int wanted, int retval, char *method_name)
 {
-  sprintf (msgbuf, "%s(): %s", method_name, msg);
-  is_int(wanted, retval, msgbuf);
+  is_int(wanted, retval, method_name);
 
   if (retval < 0)
     warn(method_name, g);
@@ -184,8 +183,8 @@ main (int argc, char *argv[])
   
   /* this must soft fail if there is not start symbol */
 #define NO_START_TEST_MSG "fail before marpa_g_start_symbol_set()"
-  is_failure(g, 43, -1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start", NO_START_TEST_MSG);
-  is_failure(g, 43, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", NO_START_TEST_MSG);
+  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start", NO_START_TEST_MSG);
+  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", NO_START_TEST_MSG);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
@@ -197,15 +196,15 @@ main (int argc, char *argv[])
   /* these must return -2 and set error code to MARPA_ERR_NOT_PRECOMPUTED */
   /* Symbols */
 #define NOT_PRECOMPUTED_TEST_MSG "fail before marpa_g_precompute()"  
-  is_failure(g, 34, -2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, 34, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, 34, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, 34, -2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, 34, -2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal", NOT_PRECOMPUTED_TEST_MSG);
   /* Rules */
-  is_failure(g, 34, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, 34, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, 34, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
+  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", NOT_PRECOMPUTED_TEST_MSG);
   
   if (marpa_g_precompute (g) < 0)
     fail("marpa_g_precompute", g);
@@ -214,25 +213,25 @@ main (int argc, char *argv[])
   /* grammar methods, per sections of api.texi's Grammar Methods */
 
   /* Symbols -- these do have @<Fail if not precomputed@>@ */
-  is_int(1, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible()");
-  is_int(1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
-  is_int(1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
-  is_int(1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
-  is_int(1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
-  is_int(0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
+  is_success(g, 1, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible()");
+  is_success(g, 1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
+  is_success(g, 1, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling()");
+  is_success(g, 1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
+  is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
+  is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
   
   /* Rules */
-  is_int(R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id()");
-  is_int(1, marpa_g_rule_is_accessible (g, R_top_1), "marpa_g_rule_is_accessible()");
-  is_int(1, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable()");
-  is_int(1, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling()");
-  is_int(0, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop()");
-  is_int(1, marpa_g_rule_is_productive (g, R_C2_3), "marpa_g_rule_is_productive()");
-  is_int(1, marpa_g_rule_length (g, R_top_1), "marpa_g_rule_length(), rule R_top_1");
-  is_int(0, marpa_g_rule_length (g, R_C2_3), "marpa_g_rule_length(), rule R_C2_3");
-  is_int(S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs(), rule R_top_1");
-  is_int(S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs(), rule R_top_1");
-  is_success(g, S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs", "rule R_top_2");
+  is_success(g, R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id()");
+  is_success(g, 1, marpa_g_rule_is_accessible (g, R_top_1), "marpa_g_rule_is_accessible()");
+  is_success(g, 1, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable()");
+  is_success(g, 1, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling()");
+  is_success(g, 0, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop()");
+  is_success(g, 1, marpa_g_rule_is_productive (g, R_C2_3), "marpa_g_rule_is_productive()");
+  is_success(g, 1, marpa_g_rule_length (g, R_top_1), "marpa_g_rule_length()");
+  is_success(g, 0, marpa_g_rule_length (g, R_C2_3), "marpa_g_rule_length()");
+  is_success(g, S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs()");
+  is_success(g, S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs()");
+  is_success(g, S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs()");
 
   /* recognizer methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -23,11 +23,15 @@
 #include "tap/basic.h"
 
 static int
+warn (const char *s, Marpa_Grammar g)
+{
+  printf ("%s returned %d: %s", s, marpa_g_error (g, NULL));
+}
+
+static int
 fail (const char *s, Marpa_Grammar g)
 {
-  const char *error_string;
-  Marpa_Error_Code errcode = marpa_g_error (g, &error_string);
-  printf ("%s returned %d: %s", s, errcode, error_string);
+  warn (s, g);
   exit (1);
 }
 
@@ -74,7 +78,6 @@ int
 main (int argc, char *argv[])
 {
   int rc;
-  const char *error_string;
 
   Marpa_Config marpa_configuration;
 
@@ -93,9 +96,8 @@ main (int argc, char *argv[])
   g = marpa_g_new (&marpa_configuration);
   if (!g)
     {
-      Marpa_Error_Code errcode =
-      marpa_c_error (&marpa_configuration, &error_string);
-      printf ("marpa_g_new returned %d: %s", errcode, error_string);
+      Marpa_Error_Code errcode = marpa_c_error (&marpa_configuration, NULL);
+      printf ("marpa_g_new returned %d", errcode);
       exit (1);
     }
 
@@ -176,11 +178,7 @@ main (int argc, char *argv[])
   is_int(-2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop() before marpa_g_precompute()");
   
   if (marpa_g_precompute (g) < 0)
-    {
-      marpa_g_error (g, &error_string);
-      puts (error_string);
-      exit (1);
-    }
+    fail("marpa_g_precompute", g);
   ok(1, "precomputation succeeded");
 
   /* grammar methods, per sections of api.texi's Grammar Methods */
@@ -208,19 +206,12 @@ main (int argc, char *argv[])
 
   /* recognizer methods */
   r = marpa_r_new (g);
-  if (!r)
-    {
-      marpa_g_error (g, &error_string);
-      puts (error_string);
-      exit (1);
-    }
+  if (!r) 
+    fail("marpa_r_new", g);
   rc = marpa_r_start_input (r);
   if (!rc)
-    {
-      marpa_g_error (g, &error_string);
-      puts (error_string);
-      exit (1);
-    }
+    fail("marpa_r_start_input", g);
+
   ok((marpa_r_is_exhausted(r)), "exhausted at earleme 0");
   
   return 0;


### PR DESCRIPTION
This adds testing for error codes and `marpa_g_symbol_is_terminal_set()` (hence on 11.4 symbols), which required some refactoring that will also help testing subsequent methods. 

2 tests fail because `marpa_g_error()` returns 0 rather than MARPA_ERR_NO_START_SYMBOL after calls to `marpa_g_symbol_is_start()` and `marpa_g_start_symbol()` before `marpa_g_start_symbol_set()`:

```
# wanted: 43
#   seen: 0
not ok 2 - marpa_g_symbol_is_start() error code
# wanted: 43
#   seen: 0
not ok 4 - marpa_g_start_symbol() error code
```