### PR TITLE
Method census on trivial grammar 11.6 sequences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,12 @@ test: work_install timestamp/do_test.stamp
 test_clean:
 	rm -f timestamp/do_test.stamp
 
+dist_clean: clean
+	rm -rf dist
+	rm -rf doc_dist
+	rm -rf doc1_dist
+	rm -f libmarpa-$(version).tar.gz libmarpa-doc-$(version).tar.gz libmarpa-doc1-$(version).tar.gz
+
 clean:
 	rm -rf work/doc
 	rm -rf work/doc1

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -156,6 +156,21 @@ trivial_grammar(Marpa_Config *config)
   return g;
 }
 
+static Marpa_Error_Code
+trivial_grammar_precompute(Marpa_Grammar g, Marpa_Symbol_ID S_start)
+{
+  Marpa_Error_Code rc;
+
+  (marpa_g_start_symbol_set (g, S_start) >= 0)
+    || fail ("marpa_g_start_symbol_set", g);
+
+  rc = marpa_g_precompute (g);
+  if (rc < 0)
+    fail("marpa_g_precompute", g);
+
+  return rc;
+}
+
 /* test retcode and error code on expected failure */
 static int
 is_failure(Marpa_Grammar g, Marpa_Error_Code errcode_wanted, int retcode_wanted, int retcode, char *method_name, char *msg)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -201,13 +201,19 @@ main (int argc, char *argv[])
   
   /* these must soft fail if there is not start symbol */
 #define NO_START_TEST_MSG "fail before marpa_g_start_symbol_set()"
-  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start", NO_START_TEST_MSG);
+
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start", "symbol is not well-formed");
+  is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_start (g, 150), "marpa_g_symbol_is_start", "symbol doesn't exist");
+  /* Returns 0 if sym_id is not the start symbol, either because the start symbol 
+     is different from sym_id, or because the start symbol has not been set yet. */
+  is_success(g, 0, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start");
   is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", NO_START_TEST_MSG);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
   /* these must succeed after the start symbol is set */
+  is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start");
   is_success(g, S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
   is_success(g, S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
   
@@ -218,7 +224,7 @@ main (int argc, char *argv[])
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive", NOT_PRECOMPUTED_TEST_MSG);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal", NOT_PRECOMPUTED_TEST_MSG);
+  is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal");
 
   /* Rules */
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", NOT_PRECOMPUTED_TEST_MSG);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -246,7 +246,7 @@ main (int argc, char *argv[])
   marpa_g_unref(g);
   g = trivial_grammar(&marpa_configuration);
   
-  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -2, marpa_g_precompute (g), "marpa_g_precompute", "with a nulling terminal");
+  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -2, marpa_g_precompute (g), "marpa_g_precompute", "before marpa_g_start_symbol_set()");
 
   /* set start symbol */
   (marpa_g_start_symbol_set (g, S_top) >= 0)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -268,12 +268,7 @@ main (int argc, char *argv[])
 
   is_failure(g, MARPA_ERR_NO_START_SYMBOL, -2, marpa_g_precompute (g), "marpa_g_precompute", "before marpa_g_start_symbol_set()");
 
-  /* set start symbol */
-  (marpa_g_start_symbol_set (g, S_top) >= 0)
-    || fail ("marpa_g_start_symbol_set", g);
-
-  if (marpa_g_precompute (g) < 0)
-    fail("marpa_g_precompute", g);
+  trivial_grammar_precompute(g, S_top);
   ok(1, "precomputation succeeded");
 
   /* Symbols -- these do have @<Fail if not precomputed@>@ */
@@ -313,6 +308,9 @@ main (int argc, char *argv[])
   /* Events */
   /* test that attempts to create events, other than nulled events,
      results in a reasonable error -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111838 */
+
+  trivial_grammar_precompute(g, S_top);
+  ok(1, "precomputation succeeded");
 
   /* Recognizer Methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -152,7 +152,7 @@ trivial_grammar(Marpa_Config *config)
 
   ((R_C2_3 = marpa_g_rule_new (g, S_C2, rhs, 0)) >= 0)
     || fail ("marpa_g_rule_new", g);
-  
+
   return g;
 }
 
@@ -167,7 +167,7 @@ is_failure(Marpa_Grammar g, Marpa_Error_Code errcode_wanted, int retcode_wanted,
 
   errcode = marpa_g_error (g, NULL);
   sprintf (msgbuf, "%s() error code", method_name);
-  is_int(errcode_wanted, errcode, msgbuf);  
+  is_int(errcode_wanted, errcode, msgbuf);
 
   marpa_g_error_clear(g);
 }
@@ -198,17 +198,17 @@ main (int argc, char *argv[])
 
   marpa_c_init (&marpa_configuration);
   g = trivial_grammar(&marpa_configuration);
-  
+
   /* Grammar Methods per sections of api.texi: Symbols, Rules, Sequnces, Ranks, Events */
 
   /* these must soft fail if there is not start symbol */
 #define NO_START_TEST_MSG "fail before marpa_g_start_symbol_set()"
 
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start", 
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start",
     "symbol is not well-formed");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_start (g, 150), "marpa_g_symbol_is_start",
     "symbol is well-formed, but doesn't exist");
-  /* Returns 0 if sym_id is not the start symbol, either because the start symbol 
+  /* Returns 0 if sym_id is not the start symbol, either because the start symbol
      is different from sym_id, or because the start symbol has not been set yet. */
   is_success(g, 0, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start");
   is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", NO_START_TEST_MSG);
@@ -219,11 +219,11 @@ main (int argc, char *argv[])
   /* these must succeed after the start symbol is set */
   is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start");
   is_success(g, S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
-  is_success(g, S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()"); 
-  
+  is_success(g, S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()");
+
   /* these must return -2 and set error code to MARPA_ERR_NOT_PRECOMPUTED */
   /* Symbols */
-#define NOT_PRECOMPUTED_TEST_MSG "fail before marpa_g_precompute()"  
+#define NOT_PRECOMPUTED_TEST_MSG "fail before marpa_g_precompute()"
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
@@ -234,23 +234,23 @@ main (int argc, char *argv[])
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", NOT_PRECOMPUTED_TEST_MSG);
-  
+
   /* expected failures on attempts to non-well-formed and non-existing symbols as terminals */
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal_set (g, -1, 1), "marpa_g_symbol_is_terminal", 
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal_set (g, -1, 1), "marpa_g_symbol_is_terminal",
     "symbol is not well-formed");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal_set (g, 150, 1), "marpa_g_symbol_is_terminal",
     "symbol is well-formed, but doesn't exist");
   /* set a nulling symbol to be terminal and test precomputation failure */
-  is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_C1, 1), 
+  is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_C1, 1),
     "marpa_g_symbol_is_terminal_set()");
-  is_failure(g, MARPA_ERR_TERMINAL_IS_LOCKED, -2, marpa_g_symbol_is_terminal_set(g, S_C1, 0), 
+  is_failure(g, MARPA_ERR_TERMINAL_IS_LOCKED, -2, marpa_g_symbol_is_terminal_set(g, S_C1, 0),
     "marpa_g_symbol_is_terminal_set", "on a symbol already set to be a terminal");
   is_failure(g, MARPA_ERR_NULLING_TERMINAL, -2, marpa_g_precompute (g), "marpa_g_precompute", "with a nulling terminal");
-  
+
   /* terminals are locked after setting, so we recreate the grammar */
   marpa_g_unref(g);
   g = trivial_grammar(&marpa_configuration);
-  
+
   is_failure(g, MARPA_ERR_NO_START_SYMBOL, -2, marpa_g_precompute (g), "marpa_g_precompute", "before marpa_g_start_symbol_set()");
 
   /* set start symbol */
@@ -268,14 +268,14 @@ main (int argc, char *argv[])
   is_success(g, 1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
   is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal(g, -1), "marpa_g_symbol_is_terminal", 
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal(g, -1), "marpa_g_symbol_is_terminal",
     "symbol is not well-formed");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal (g, 150), "marpa_g_symbol_is_terminal",
     "symbol is well-formed, but doesn't exist");
 
-  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_symbol_is_terminal_set (g, S_top, 0), 
+  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_symbol_is_terminal_set (g, S_top, 0),
     "marpa_g_symbol_is_terminal_set", "on precomputed grammar");
-  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_start_symbol_set (g, S_top), 
+  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_start_symbol_set (g, S_top),
     "marpa_g_start_symbol_set", "on precomputed grammar");
 
   /* Rules */
@@ -291,9 +291,17 @@ main (int argc, char *argv[])
   is_success(g, S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs()");
   is_success(g, S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs()");
 
-  /* recognizer methods */
+  /* Sequences */
+  /* try to add a nulling sequence, and make sure that it fails with an appropriate
+     error code -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111831  */
+
+  /* Events */
+  /* test that attempts to create events, other than nulled events,
+     results in a reasonable error -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111838 */
+
+  /* Recognizer Methods */
   r = marpa_r_new (g);
-  if (!r) 
+  if (!r)
     fail("marpa_r_new", g);
 
   rc = marpa_r_start_input (r);
@@ -302,6 +310,6 @@ main (int argc, char *argv[])
 
   diag ("at earleme 0");
   is_success(g, 1, marpa_r_is_exhausted(r), "marpa_r_is_exhausted()");
-  
+
   return 0;
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -304,6 +304,44 @@ main (int argc, char *argv[])
   /* Sequences */
   /* try to add a nulling sequence, and make sure that it fails with an appropriate
      error code -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111831  */
+  /* recreate the grammar */
+  marpa_g_unref(g);
+  g = trivial_grammar(&marpa_configuration);
+  /* try to add a nulling sequence */
+  is_failure(g, MARPA_ERR_SEQUENCE_LHS_NOT_UNIQUE, -2,
+    marpa_g_sequence_new (g, S_top, S_B1, S_B2, 0, MARPA_PROPER_SEPARATION),
+      "marpa_g_sequence_new", "with non-unique lhs");
+  /* test error codes of other sequence methods */
+  /* On success, if rule rule_id is not a sequence rule, 0. */
+  is_success(g, 0, marpa_g_rule_is_proper_separation (g, R_top_1), "marpa_g_rule_is_proper_separation");
+  /* -1 is returned if and only if the rule is valid but not a sequence rule. */
+  is_failure(g, 0, -1, marpa_g_sequence_min (g, R_top_1),
+    "marpa_g_sequence_min", "non-sequence rule id");
+  /* If rule_id is not a sequence rule, does not exist or is not well-formed;
+     or on other failure, -2. */
+  is_failure(g, 0, -2, marpa_g_sequence_separator (g, R_top_1),
+    "marpa_g_sequence_separator", "non-sequence rule id");
+  is_success(g, 0, marpa_g_symbol_is_counted (g, R_top_1), "marpa_g_symbol_is_counted");
+  /* invalid rule/symbol id */
+  is_failure(g, MARPA_ERR_INVALID_RULE_ID, -2, marpa_g_rule_is_proper_separation (g, -1),
+    "marpa_g_rule_is_proper_separation", "malformed rule id");
+  is_failure(g, MARPA_ERR_INVALID_RULE_ID, -2, marpa_g_sequence_min (g, -1),
+    "marpa_g_sequence_min", "malformed rule id");
+  is_failure(g, MARPA_ERR_INVALID_RULE_ID, -2, marpa_g_sequence_separator (g, -1),
+    "marpa_g_sequence_separator", "malformed rule id");
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_counted (g, -1),
+    "marpa_g_symbol_is_counted", "malformed rule id");
+  /* valid, but non-existent rule/symbol id */
+  is_failure(g, MARPA_ERR_NO_SUCH_RULE_ID, -2, marpa_g_rule_is_proper_separation (g, 150),
+    "marpa_g_rule_is_proper_separation", "non-existent rule id");
+  is_failure(g, MARPA_ERR_NO_SUCH_RULE_ID, -2, marpa_g_sequence_min (g, 150),
+    "marpa_g_sequence_min", "non-existent rule id");
+  is_failure(g, MARPA_ERR_NO_SUCH_RULE_ID, -2, marpa_g_sequence_separator (g, 150),
+    "marpa_g_sequence_separator", "non-existent rule id");
+  is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -2, marpa_g_symbol_is_counted (g, 150),
+    "marpa_g_symbol_is_counted", "non-existent rule id");
+
+  /* Ranks */
 
   /* Events */
   /* test that attempts to create events, other than nulled events,

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -235,6 +235,11 @@ main (int argc, char *argv[])
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", NOT_PRECOMPUTED_TEST_MSG);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", NOT_PRECOMPUTED_TEST_MSG);
   
+  /* expected failures on attempts to non-well-formed and non-existing symbols as terminals */
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal_set (g, -1, 1), "marpa_g_symbol_is_terminal", 
+    "symbol is not well-formed");
+  is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal_set (g, 150, 1), "marpa_g_symbol_is_terminal",
+    "symbol is well-formed, but doesn't exist");
   /* set a nulling symbol to be terminal and test precomputation failure */
   is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_C1, 1), 
     "marpa_g_symbol_is_terminal_set()");
@@ -263,6 +268,10 @@ main (int argc, char *argv[])
   is_success(g, 1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
   is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal(g, -1), "marpa_g_symbol_is_terminal", 
+    "symbol is not well-formed");
+  is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal (g, 150), "marpa_g_symbol_is_terminal",
+    "symbol is well-formed, but doesn't exist");
 
   is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_symbol_is_terminal_set (g, S_top, 0), 
     "marpa_g_symbol_is_terminal_set", "on precomputed grammar");

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -199,11 +199,15 @@ main (int argc, char *argv[])
   marpa_c_init (&marpa_configuration);
   g = trivial_grammar(&marpa_configuration);
   
+  /* Grammar Methods per sections of api.texi: Symbols, Rules, Sequnces, Ranks, Events */
+
   /* these must soft fail if there is not start symbol */
 #define NO_START_TEST_MSG "fail before marpa_g_start_symbol_set()"
 
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start", "symbol is not well-formed");
-  is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_start (g, 150), "marpa_g_symbol_is_start", "symbol doesn't exist");
+  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start", 
+    "symbol is not well-formed");
+  is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_start (g, 150), "marpa_g_symbol_is_start",
+    "symbol is well-formed, but doesn't exist");
   /* Returns 0 if sym_id is not the start symbol, either because the start symbol 
      is different from sym_id, or because the start symbol has not been set yet. */
   is_success(g, 0, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start");
@@ -252,8 +256,6 @@ main (int argc, char *argv[])
     fail("marpa_g_precompute", g);
   ok(1, "precomputation succeeded");
 
-  /* Grammar Methods per sections of api.texi */
-
   /* Symbols -- these do have @<Fail if not precomputed@>@ */
   is_success(g, 1, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible()");
   is_success(g, 1, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable()");
@@ -262,9 +264,11 @@ main (int argc, char *argv[])
   is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
 
-  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_symbol_is_terminal_set(g, S_top, 0), 
+  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_symbol_is_terminal_set (g, S_top, 0), 
     "marpa_g_symbol_is_terminal_set", "on precomputed grammar");
-  
+  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_start_symbol_set (g, S_top), 
+    "marpa_g_start_symbol_set", "on precomputed grammar");
+
   /* Rules */
   is_success(g, R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id()");
   is_success(g, 1, marpa_g_rule_is_accessible (g, R_top_1), "marpa_g_rule_is_accessible()");


### PR DESCRIPTION
Test failures so far:
```
# wanted: 0
#   seen: -1
not ok 5 - marpa_g_symbol_is_start
marpa_g_symbol_is_start returned 0
```
This one left from #27 (Symbols) (per the last comment)

```
# wanted: 0
#   seen: 1
not ok 65 - marpa_g_rule_is_proper_separation
```
The doc: _On success, if rule rule_id is not a sequence rule, 0._

```
# wanted: -2
#   seen: -1
not ok 68 - marpa_g_sequence_separator(): non-sequence rule id
```
Doc: _If rule_id is not a sequence rule, does not exist or is not well-formed; or on other failure, -2._
```
# wanted: -2
#   seen: -1
not ok 85 - marpa_g_symbol_is_counted(): non-existent rule id
```
Doc: _On failure, -2._
