### PR TITLE
marpa_m_test() 

### DIFF
--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -250,8 +250,8 @@ main (int argc, char *argv[])
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", MSG_NOT_PRECOMPUTED);
 
   /* expected failures on attempts to non-well-formed and non-existing symbols as terminals */
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal_set (g, -1, 1),
-    "marpa_g_symbol_is_terminal", MARPA_TEST_MSG_INVALID_SYMBOL_ID);
+  is_failure_invalid_symbol_id
+    (g, marpa_g_symbol_is_terminal_set (g, -1, 1), "marpa_g_symbol_is_terminal");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal_set (g, 42, 1),
     "marpa_g_symbol_is_terminal", MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID);
   /* set a nulling symbol to be terminal and test precomputation failure */
@@ -277,8 +277,8 @@ main (int argc, char *argv[])
   is_success(g, 1, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive()");
   is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start()");
   is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal()");
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_terminal(g, -1),
-    "marpa_g_symbol_is_terminal", MARPA_TEST_MSG_INVALID_SYMBOL_ID);
+  is_failure_invalid_symbol_id
+    (g, marpa_g_symbol_is_terminal(g, -1), "marpa_g_symbol_is_terminal");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal (g, 42),
     "marpa_g_symbol_is_terminal", MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID);
 
@@ -327,8 +327,8 @@ main (int argc, char *argv[])
     "marpa_g_sequence_min", MARPA_TEST_MSG_INVALID_RULE_ID);
   is_failure(g, MARPA_ERR_INVALID_RULE_ID, -2, marpa_g_sequence_separator (g, -1),
     "marpa_g_sequence_separator", MARPA_TEST_MSG_INVALID_RULE_ID);
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_counted (g, -1),
-    "marpa_g_symbol_is_counted", MARPA_TEST_MSG_INVALID_SYMBOL_ID);
+  is_failure_invalid_symbol_id
+    (g, marpa_g_symbol_is_counted (g, -1), "marpa_g_symbol_is_counted");
   /* well-formed, but invalid rule/symbol id */
   is_failure(g, MARPA_ERR_NO_SUCH_RULE_ID, -1, marpa_g_rule_is_proper_separation (g, 42),
     "marpa_g_rule_is_proper_separation", MARPA_TEST_MSG_NO_SUCH_RULE_ID);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -221,10 +221,11 @@ how
   void marpa_m_object_t_set(Marpa_Tree t)
   void marpa_m_object_v_set(Marpa_Value v)
 
-  typedef struct {
+  struct marpa_method_spec {
     int (*fp)(...) ptr;
     const char *parm_spec;
-  } Marpa_Method_Spec;
+  };
+  typedef struct marpa_method_spec Marpa_Method_Spec;
 
   Marpa_Method_Spec marpa_m_method_spec(const char *method_name)
   char *marpa_m_error_message (Marpa_Error_Code error_code)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -611,13 +611,6 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_g_rule_null_high_set", g, R_top_2, flag, -2, MARPA_ERR_PRECOMPUTED);
   marpa_m_test("marpa_g_rule_null_high", g, R_top_2, flag);
 
-  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_rule_rank_set (g, R_top_1, rank),
-    "marpa_g_rule_rank_set", "on precomputed grammar");
-  is_success(g, rank, marpa_g_rule_rank (g, R_top_1), "marpa_g_rule_rank()");
-  is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_rule_null_high_set (g, R_top_2, flag),
-    "marpa_g_rule_null_high_set", "on precomputed grammar");
-  is_success(g, 1, marpa_g_rule_null_high (g, R_top_2), "marpa_g_rule_null_high()");
-
   /* recreate the grammar to test event methods except nulled */
   marpa_g_unref(g);
   g = marpa_g_trivial_new(&marpa_configuration);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -157,22 +157,6 @@ marpa_g_trivial_precompute(Marpa_Grammar g, Marpa_Symbol_ID S_start)
   return rc;
 }
 
-/* test retcode and error code on expected failure */
-static int
-is_failure(Marpa_Grammar g, Marpa_Error_Code errcode_wanted, int retcode_wanted, int retcode, char *method_name, char *msg)
-{
-  int errcode;
-
-  sprintf (msgbuf, "%s(): %s", method_name, msg);
-  is_int(retcode_wanted, retcode, msgbuf);
-
-  errcode = marpa_g_error (g, NULL);
-  sprintf (msgbuf, "%s() error code", method_name);
-  is_int(errcode_wanted, errcode, msgbuf);
-
-  marpa_g_error_clear(g);
-}
-
 /* test retval and print error code on unexpected failure */
 static int
 is_success(Marpa_Grammar g, int wanted, int retval, char *method_name)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -233,6 +233,7 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_g_rule_null_high_set", &marpa_g_rule_null_high_set, "%r, %i" },
   { "marpa_g_rule_null_high", &marpa_g_rule_null_high, "%r" },
 
+  { "marpa_r_is_exhausted", &marpa_r_is_exhausted, "" },
 };
 
 static Marpa_Method_Spec
@@ -308,6 +309,8 @@ marpa_m_test(const char* name, ...)
   R_id = S_id = S_id1 = S_id2 = intarg = intarg1 = ARG_UNDEF;
   if (strncmp(name, "marpa_g_", 8) == 0)
     g = va_arg(args, Marpa_Grammar);
+  else if (strncmp(name, "marpa_r_", 8) == 0)
+    r = va_arg(args, Marpa_Recognizer);
 
   /* unpack arguments */
   if (ms.as == "")
@@ -640,7 +643,7 @@ int marpa_g_symbol_is_prediction_event_set (g, S_top, value)
     fail("marpa_r_start_input", g);
 
   diag ("at earleme 0");
-  is_success(g, 1, marpa_r_is_exhausted(r), "marpa_r_is_exhausted()");
+  marpa_m_test("marpa_r_is_exhausted", r, 1);
 
   return 0;
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -228,6 +228,8 @@ marpa_m_method_spec(const char *name)
     ms.p = &marpa_g_symbol_is_terminal_set, ms.as = "%s, %i";
   else if ( strcmp(name, "marpa_g_start_symbol") == 0 )
     ms.p = &marpa_g_start_symbol, ms.as = "";
+  else if ( strcmp(name, "marpa_g_highest_symbol_id") == 0 )
+    ms.p = &marpa_g_highest_symbol_id, ms.as = "";
   else
   {
     printf("No spec yet for Marpa method %s().\n", name);
@@ -365,15 +367,14 @@ main (int argc, char *argv[])
      is different from sym_id, or because the start symbol has not been set yet. */
   marpa_m_test("marpa_g_symbol_is_start", g, S_top, 0);
   marpa_m_test("marpa_g_start_symbol", g, -1, MARPA_ERR_NO_START_SYMBOL);
-  is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", MARPA_TEST_MSG_NO_START_SYMBOL);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
   /* these must succeed after the start symbol is set */
   marpa_m_test("marpa_g_symbol_is_start", g, S_top, 1);
-  is_success(g, S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
-  is_success(g, S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()");
+  marpa_m_test("marpa_g_start_symbol", g, S_top);
+  marpa_m_test("marpa_g_highest_symbol_id", g, S_C2);
 
   /* these must return -2 and set error code to MARPA_ERR_NOT_PRECOMPUTED */
   /* Symbols */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -599,7 +599,7 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_g_rule_rank_set", g, R_top_2, positive_rank);
 
   marpa_m_test("marpa_g_rule_null_high_set", g, R_top_2, flag, -2, MARPA_ERR_PRECOMPUTED);
-  marpa_m_test("marpa_g_rule_null_high", g, R_top_2, flag);
+  marpa_m_test("marpa_g_rule_null_high", g, R_top_2, -2, MARPA_ERR_PRECOMPUTED);
 
   /* recreate the grammar to test event methods except nulled */
   marpa_g_unref(g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -219,12 +219,12 @@ struct marpa_method_spec {
 
 typedef struct marpa_method_spec Marpa_Method_Spec;
 
-#define MAX_METHSPEC 4
-const Marpa_Method_Spec methspec[MAX_METHSPEC] = {
+const Marpa_Method_Spec methspec[] = {
   { "marpa_g_symbol_is_start", &marpa_g_symbol_is_start, "%s" },
   { "marpa_g_symbol_is_terminal_set", &marpa_g_symbol_is_terminal_set, "%s, %i" },
   { "marpa_g_start_symbol", &marpa_g_start_symbol, "" },
-  { "marpa_g_highest_symbol_id", &marpa_g_highest_symbol_id, ""}
+  { "marpa_g_highest_symbol_id", &marpa_g_highest_symbol_id, ""},
+  { "marpa_g_symbol_is_accessible", &marpa_g_symbol_is_accessible, "%s" },
 };
 
 static Marpa_Method_Spec
@@ -233,7 +233,7 @@ marpa_m_method_spec(const char *name)
   Marpa_Method_Spec ms;
   int i;
 
-  for (i = 0; i < MAX_METHSPEC; i++)
+  for (i = 0; i < sizeof(methspec) / sizeof(Marpa_Method_Spec); i++)
   {
     if ( strcmp(name, methspec[i].n ) == 0 )
     {
@@ -252,11 +252,11 @@ struct marpa_m_error {
 
 typedef struct marpa_m_error Marpa_Method_Error;
 
-#define MAX_ERRSPEC 3
-const Marpa_Method_Error errspec[MAX_ERRSPEC] = {
+const Marpa_Method_Error errspec[] = {
   { MARPA_ERR_NO_START_SYMBOL, "no start symbol" },
   { MARPA_ERR_INVALID_SYMBOL_ID, "invalid symbol id" },
   { MARPA_ERR_NO_SUCH_SYMBOL_ID, "no such symbol id" },
+  { MARPA_ERR_NOT_PRECOMPUTED, "grammar not precomputed" },
 };
 
 static char *marpa_m_error_message (Marpa_Error_Code error_code)
@@ -264,7 +264,7 @@ static char *marpa_m_error_message (Marpa_Error_Code error_code)
   Marpa_Method_Error me;
   int i;
 
-  for (i = 0; i < MAX_ERRSPEC; i++)
+  for (i = 0; i < sizeof(errspec) / sizeof(Marpa_Method_Error); i++)
   {
     if ( error_code == errspec[i].c )
     {
@@ -406,7 +406,7 @@ main (int argc, char *argv[])
   /* these must return -2 and set error code to MARPA_ERR_NOT_PRECOMPUTED */
   /* Symbols */
 #define MSG_NOT_PRECOMPUTED "fail before marpa_g_precompute()"
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_accessible  (g, S_C2), "marpa_g_symbol_is_accessible", MSG_NOT_PRECOMPUTED);
+  marpa_m_test("marpa_g_symbol_is_accessible", g, S_C2, -2, MARPA_ERR_NOT_PRECOMPUTED);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", MSG_NOT_PRECOMPUTED);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", MSG_NOT_PRECOMPUTED);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive", MSG_NOT_PRECOMPUTED);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -614,6 +614,16 @@ main (int argc, char *argv[])
   ok(1, "precomputation succeeded");
 
   /* Ranks methods on precomputed grammar */
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, rank, -2, MARPA_ERR_PRECOMPUTED);
+  ok
+  (
+    marpa_g_rule_rank(g, R_top_1) == rank && marpa_g_error(g, NULL) == MARPA_ERR_NONE,
+    "direct marpa_g_rule_rank() on negative rank, error checked via marpa_g_error()"
+  );
+
+  marpa_m_test("marpa_g_rule_null_high_set", g, R_top_2, flag, -2, MARPA_ERR_PRECOMPUTED);
+  marpa_m_test("marpa_g_rule_null_high", g, R_top_2, flag);
+
   is_failure(g, MARPA_ERR_PRECOMPUTED, -2, marpa_g_rule_rank_set (g, R_top_1, rank),
     "marpa_g_rule_rank_set", "on precomputed grammar");
   is_success(g, rank, marpa_g_rule_rank (g, R_top_1), "marpa_g_rule_rank()");

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -221,9 +221,13 @@ how
   void marpa_m_object_t_set(Marpa_Tree t)
   void marpa_m_object_v_set(Marpa_Value v)
 
-  int (*marpa_m_pointer)(const char *method_name)
-  char *marpa_m_error_message (const char *method_name)
-  char *marpa_m_parameter_spec (const char *method_name)
+  typedef struct {
+    int (*fp)(...) ptr;
+    const char *parm_spec;
+  } Marpa_Method_Spec;
+
+  Marpa_Method_Spec marpa_m_method_spec(const char *method_name)
+  char *marpa_m_error_message (Marpa_Error_Code error_code)
 
     %s -- Marpa_Symbol_ID
     %r -- Marpa_Rule_ID

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -342,10 +342,10 @@ marpa_m_test(const char* name, ...)
   {
     /* failure seen */
     if ( rv_seen < 0 )
-      if
-        (g != NULL) warn(name, g);
-      else
-        printf("%s() unexpectedly returned %d.", name, rv_seen);
+    {
+      sprintf(msgbuf, "%s() unexpectedly returned %d.", name, rv_seen);
+      ok(0, msgbuf);
+    }
     /* success seen */
     else {
       sprintf(desc_buf, "%s() succeeded", name);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -225,6 +225,10 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_g_start_symbol", &marpa_g_start_symbol, "" },
   { "marpa_g_highest_symbol_id", &marpa_g_highest_symbol_id, ""},
   { "marpa_g_symbol_is_accessible", &marpa_g_symbol_is_accessible, "%s" },
+  { "marpa_g_symbol_is_nullable", &marpa_g_symbol_is_nullable, "%s" },
+  { "marpa_g_symbol_is_nulling", &marpa_g_symbol_is_nulling, "%s" },
+  { "marpa_g_symbol_is_productive", &marpa_g_symbol_is_productive, "%s" },
+  { "marpa_g_symbol_is_terminal",  &marpa_g_symbol_is_terminal, "%s" },
 };
 
 static Marpa_Method_Spec
@@ -407,10 +411,10 @@ main (int argc, char *argv[])
   /* Symbols */
 #define MSG_NOT_PRECOMPUTED "fail before marpa_g_precompute()"
   marpa_m_test("marpa_g_symbol_is_accessible", g, S_C2, -2, MARPA_ERR_NOT_PRECOMPUTED);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nullable (g, S_A1), "marpa_g_symbol_is_nullable", MSG_NOT_PRECOMPUTED);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_nulling (g, S_A1), "marpa_g_symbol_is_nulling", MSG_NOT_PRECOMPUTED);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_symbol_is_productive (g, S_top), "marpa_g_symbol_is_productive", MSG_NOT_PRECOMPUTED);
-  is_success(g, 0, marpa_g_symbol_is_terminal(g, S_top), "marpa_g_symbol_is_terminal");
+  marpa_m_test("marpa_g_symbol_is_nullable", g, S_A1, -2, MARPA_ERR_NOT_PRECOMPUTED);
+  marpa_m_test("marpa_g_symbol_is_nulling", g, S_A1, -2, MARPA_ERR_NOT_PRECOMPUTED);
+  marpa_m_test("marpa_g_symbol_is_productive", g, S_top, -2, MARPA_ERR_NOT_PRECOMPUTED);
+  marpa_m_test("marpa_g_symbol_is_terminal", g, S_top, 0);
 
   /* Rules */
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", MSG_NOT_PRECOMPUTED);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -399,6 +399,15 @@ marpa_m_test(const char* name, ...)
       is_int( rv_wanted, rv_seen, desc_buf );
     }
   }
+  /* marpa_g_rule_rank() and marpa_g_rule_rank_set() may return negative values,
+     but they are actually ranks if marpa_g_error() returns MARPA_ERR_NONE.
+     So, we don't count them as failures. */
+  else if ( strncmp( name, "marpa_g_rule_rank", 17 ) == 0
+              && marpa_g_error(g, NULL) == MARPA_ERR_NONE )
+    {
+      sprintf(desc_buf, "%s() succeeded", name);
+      is_int( rv_wanted, rv_seen, desc_buf );
+    }
   /* failure wanted */
   else
   {
@@ -412,17 +421,10 @@ marpa_m_test(const char* name, ...)
       g = va_arg(args, Marpa_Grammar);
     err_seen = marpa_g_error(g, NULL);
 
-    /* MARPA_ERR_NONE on negative return value */
     if (err_seen == MARPA_ERR_NONE && rv_seen < 0)
     {
-      /* marpa_g_rule_rank() and marpa_g_rule_rank_set() may return negative values,
-         but they are actually ranks if marpa_g_error() returns MARPA_ERR_NONE.
-         So, we don't count them as test failures. */
-      if ( strncmp( name, "marpa_g_rule_rank", 17 ) != 0 )
-      {
-        sprintf(msgbuf, "%s(): marpa_g_error() returned MARPA_ERR_NONE, but return value was %d.", name, rv_seen);
-        ok(0, msgbuf);
-      }
+      sprintf(msgbuf, "%s(): marpa_g_error() returned MARPA_ERR_NONE, but return value was %d.", name, rv_seen);
+      ok(0, msgbuf);
     }
     /* test error code */
     else
@@ -587,7 +589,7 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_g_symbol_is_counted", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
 
   /* Ranks */
-  rank = -1;
+  rank = -2;
   marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, rank, rank);
   marpa_m_test("marpa_g_rule_rank", g, R_top_1, rank);
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -173,19 +173,6 @@ is_failure(Marpa_Grammar g, Marpa_Error_Code errcode_wanted, int retcode_wanted,
   marpa_g_error_clear(g);
 }
 
-/* check that method_name returned -2 and
-   error code is set to MARPA_ERR_INVALID_SYMBOL_ID
-   */
-#define MARPA_TEST_MSG_NO_START_SYMBOL "fail before marpa_g_start_symbol_set()"
-#define MARPA_TEST_MSG_INVALID_SYMBOL_ID "malformed symbol id"
-#define MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID "invalid symbol id"
-static int
-is_failure_invalid_symbol_id(Marpa_Grammar g, int retcode, char *method_name)
-{
-  return is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, retcode, method_name,
-    MARPA_TEST_MSG_INVALID_SYMBOL_ID);
-}
-
 /* test retval and print error code on unexpected failure */
 static int
 is_success(Marpa_Grammar g, int wanted, int retval, char *method_name)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -240,6 +240,17 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
 
   { "marpa_g_precompute", &marpa_g_precompute, "" },
+
+  { "marpa_g_highest_rule_id", &marpa_g_highest_rule_id, "" },
+  { "marpa_g_rule_is_accessible", &marpa_g_rule_is_accessible, "%r" },
+  { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
+  { "marpa_g_rule_is_nulling", &marpa_g_rule_is_nulling, "%r" },
+  { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
+  { "marpa_g_rule_is_productive", &marpa_g_rule_is_productive, "%r" },
+  { "marpa_g_rule_length", &marpa_g_rule_length, "%r" },
+  { "marpa_g_rule_lhs", &marpa_g_rule_lhs, "%r" },
+  { "marpa_g_rule_rhs", &marpa_g_rule_rhs, "%r, %i" },
+
 };
 
 static Marpa_Method_Spec
@@ -324,7 +335,7 @@ marpa_m_test(const char* name, ...)
   /* unpack arguments */
   if (ms.as == "")
   {
-    /* dispatch based on what object is set */
+    /* method dispatch based on what object is set */
     if (g != NULL) rv_seen = ms.p(g);
     else if (r != NULL) rv_seen = ms.p(r);
   }
@@ -340,10 +351,16 @@ marpa_m_test(const char* name, ...)
 
       curr_arg = strtok(NULL, " ,-");
     }
-    /* call marpa method based on signature */
+    /* call marpa method based on argspec */
     if (strcmp(ms.as, "%s") == 0) rv_seen = ms.p(g, S_id);
-    if (strcmp(ms.as, "%r") == 0) rv_seen = ms.p(g, R_id);
     else if (strcmp(ms.as, "%s, %i") == 0) rv_seen = ms.p(g, S_id, intarg);
+    else if (strcmp(ms.as, "%r") == 0) rv_seen = ms.p(g, R_id);
+    else if (strcmp(ms.as, "%r, %i") == 0) rv_seen = ms.p(g, R_id, intarg);
+    else
+    {
+      printf("No method yet for argument spec %s.\n", ms.as);
+      exit(1);
+    }
   }
 
   rv_wanted = va_arg(args, int);
@@ -471,17 +488,17 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_g_start_symbol_set", g, S_top, -2, MARPA_ERR_PRECOMPUTED);
 
   /* Rules */
-  is_success(g, R_C2_3, marpa_g_highest_rule_id (g), "marpa_g_highest_rule_id()");
-  is_success(g, 1, marpa_g_rule_is_accessible (g, R_top_1), "marpa_g_rule_is_accessible()");
-  is_success(g, 1, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable()");
-  is_success(g, 1, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling()");
-  is_success(g, 0, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop()");
-  is_success(g, 1, marpa_g_rule_is_productive (g, R_C2_3), "marpa_g_rule_is_productive()");
-  is_success(g, 1, marpa_g_rule_length (g, R_top_1), "marpa_g_rule_length()");
-  is_success(g, 0, marpa_g_rule_length (g, R_C2_3), "marpa_g_rule_length()");
-  is_success(g, S_top, marpa_g_rule_lhs (g, R_top_1), "marpa_g_rule_lhs()");
-  is_success(g, S_A1, marpa_g_rule_rhs (g, R_top_1, 0), "marpa_g_rule_rhs()");
-  is_success(g, S_A2, marpa_g_rule_rhs (g, R_top_2, 0), "marpa_g_rule_rhs()");
+  marpa_m_test("marpa_g_highest_rule_id", g, R_C2_3);
+  marpa_m_test("marpa_g_rule_is_accessible", g, R_top_1, 1);
+  marpa_m_test("marpa_g_rule_is_nullable", g, R_top_2, 1);
+  marpa_m_test("marpa_g_rule_is_nulling", g, R_top_2, 1);
+  marpa_m_test("marpa_g_rule_is_loop", g, R_C2_3, 0);
+  marpa_m_test("marpa_g_rule_is_productive", g, R_C2_3, 1);
+  marpa_m_test("marpa_g_rule_length", g, R_top_1, 1);
+  marpa_m_test("marpa_g_rule_length", g, R_C2_3, 0);
+  marpa_m_test("marpa_g_rule_lhs", g, R_top_1, S_top);
+  marpa_m_test("marpa_g_rule_rhs", g, R_top_1, 0, S_A1);
+  marpa_m_test("marpa_g_rule_rhs", g, R_top_2, 0, S_A2);
 
   /* Sequences */
   /* try to add a nulling sequence, and make sure that it fails with an appropriate

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -548,9 +548,6 @@ main (int argc, char *argv[])
   marpa_g_unref(g);
   g = marpa_g_trivial_new(&marpa_configuration);
 
-  is_failure(g, MARPA_ERR_NOT_A_SEQUENCE, -1, marpa_g_sequence_min (g, R_top_1),
-    "marpa_g_sequence_min", "non-sequence rule id");
-
   /* try to add a nulling sequence */
   marpa_m_test("marpa_g_sequence_new", g, S_top, S_B1, S_B2, 0, MARPA_PROPER_SEPARATION,
     -2, MARPA_ERR_SEQUENCE_LHS_NOT_UNIQUE);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -243,7 +243,7 @@ static char *marpa_m_error_message (Marpa_Error_Code error_code)
 }
 
 static int
-marpa_m_success_test(const char* name, ...)
+marpa_m_test(const char* name, ...)
 {
   Marpa_Method_Spec ms;
 
@@ -319,14 +319,14 @@ main (int argc, char *argv[])
     MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID);
   /* Returns 0 if sym_id is not the start symbol, either because the start symbol
      is different from sym_id, or because the start symbol has not been set yet. */
-  marpa_m_success_test("marpa_g_symbol_is_start", g, S_top, 0);
+  marpa_m_test("marpa_g_symbol_is_start", g, S_top, 0);
   is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", MARPA_TEST_MSG_NO_START_SYMBOL);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)
     || fail ("marpa_g_start_symbol_set", g);
 
   /* these must succeed after the start symbol is set */
-  marpa_m_success_test("marpa_g_symbol_is_start", g, S_top, 1);
+  marpa_m_test("marpa_g_symbol_is_start", g, S_top, 1);
   is_success(g, S_top, marpa_g_start_symbol (g), "marpa_g_start_symbol()");
   is_success(g, S_C2, marpa_g_highest_symbol_id (g), "marpa_g_highest_symbol_id()");
 
@@ -350,7 +350,7 @@ main (int argc, char *argv[])
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal_set (g, 42, 1),
     "marpa_g_symbol_is_terminal", MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID);
   /* set a nulling symbol to be terminal and test precomputation failure */
-  marpa_m_success_test("marpa_g_symbol_is_terminal_set", g, S_C1, 1, 1);
+  marpa_m_test("marpa_g_symbol_is_terminal_set", g, S_C1, 1, 1);
   is_success(g, 1, marpa_g_symbol_is_terminal_set(g, S_C1, 1),
 
     "marpa_g_symbol_is_terminal_set()");

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -295,10 +295,22 @@ marpa_m_test(const char* name, ...)
 
   rv_wanted = va_arg(args, int);
 
+  /* success wanted */
   if ( rv_wanted >= 0 )
   {
-    is_int( rv_wanted, rv_seen, name );
+    /* failure seen */
+    if ( rv_seen < 0 )
+      if
+        (g != NULL) warn(name, g);
+      else
+        printf("%s() unexpectedly returned %d.", name, rv_seen);
+    /* success seen */
+    else {
+      sprintf(desc_buf, "%s() succeeded", name);
+      is_int( rv_wanted, rv_seen, desc_buf );
+    }
   }
+  /* failure wanted */
   else
   {
     err_wanted = va_arg(args, int);
@@ -308,7 +320,10 @@ marpa_m_test(const char* name, ...)
 
     err_seen = marpa_g_error(g, NULL);
 
-    sprintf(desc_buf, "%s erred on %s", name, marpa_m_error_message(err_seen));
+    sprintf(desc_buf, "%s() failed, returned %d", name, rv_seen);
+    is_int( rv_wanted, rv_seen, desc_buf );
+
+    sprintf(desc_buf, "%s() erred on %s", name, marpa_m_error_message(err_seen));
     is_int( err_wanted, err_seen, desc_buf );
   }
 
@@ -341,7 +356,7 @@ main (int argc, char *argv[])
   S_invalid = -1;
   S_no_such = 42;
   /* these must soft fail if there is not start symbol */
-  marpa_m_test("marpa_g_symbol_is_start", g, S_invalid, -1, MARPA_ERR_INVALID_SYMBOL_ID);
+  marpa_m_test("marpa_g_symbol_is_start", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
   marpa_m_test("marpa_g_symbol_is_start", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
   /* Returns 0 if sym_id is not the start symbol, either because the start symbol
      is different from sym_id, or because the start symbol has not been set yet. */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -157,18 +157,6 @@ marpa_g_trivial_precompute(Marpa_Grammar g, Marpa_Symbol_ID S_start)
   return rc;
 }
 
-/* test retval and print error code on unexpected failure */
-static int
-is_success(Marpa_Grammar g, int wanted, int retval, char *method_name)
-{
-  is_int(wanted, retval, method_name);
-
-  if (retval < 0 && strstr(method_name, "marpa_g_rule_rank") == NULL )
-    warn(method_name, g);
-
-  marpa_g_error_clear(g);
-}
-
 /* Marpa method test interface */
 
 typedef int (*marpa_m_pointer)();
@@ -412,7 +400,7 @@ marpa_m_test(const char* name, ...)
     /* test error code */
     else
     {
-      sprintf(desc_buf, "%s() error: %s", name, marpa_m_error_message(err_seen));
+      sprintf(desc_buf, "%s() error is: %s", name, marpa_m_error_message(err_seen));
       is_int( err_wanted, err_seen, desc_buf );
     }
   }
@@ -595,11 +583,7 @@ main (int argc, char *argv[])
 
   /* Ranks methods on precomputed grammar */
   marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, rank, -2, MARPA_ERR_PRECOMPUTED);
-  ok
-  (
-    marpa_g_rule_rank(g, R_top_1) == rank && marpa_g_error(g, NULL) == MARPA_ERR_NONE,
-    "direct marpa_g_rule_rank() on negative rank, error checked via marpa_g_error()"
-  );
+  marpa_m_test("marpa_g_rule_rank", g, R_top_1, -2, MARPA_ERR_PRECOMPUTED);
 
   marpa_m_test("marpa_g_rule_null_high_set", g, R_top_2, flag, -2, MARPA_ERR_PRECOMPUTED);
   marpa_m_test("marpa_g_rule_null_high", g, R_top_2, flag);
@@ -651,7 +635,6 @@ int marpa_g_symbol_is_prediction_event_set (g, S_top, value)
   if (!rc)
     fail("marpa_r_start_input", g);
 
-  /* */
   marpa_m_grammar_set(g);
   diag ("at earleme 0");
   marpa_m_test("marpa_r_is_exhausted", r, 1);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -198,6 +198,52 @@ is_success(Marpa_Grammar g, int wanted, int retval, char *method_name)
   marpa_g_error_clear(g);
 }
 
+/*
+
+now
+
+  is_success(g, 1, marpa_g_symbol_is_start (g, S_top), "marpa_g_symbol_is_start");
+  is_failure(g,
+    MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", MARPA_TEST_MSG_NO_START_SYMBOL);
+
+then
+
+  marpa_m_object_g_set(Marpa_Grammar g);
+  marpa_m_test_success("marpa_g_symbol_is_start", S_top, 1);
+  marpa_m_test_failure("marpa_g_symbol_is_start", S_top, -1, MARPA_ERR_NO_START_SYMBOL);
+
+how
+
+  void marpa_m_object_g_set(Marpa_Grammar g)
+  void marpa_m_object_r_set(Marpa_Recognizer r)
+  void marpa_m_object_b_set(Marpa_Bocage b)
+  void marpa_m_object_o_set(Marpa_Order o)
+  void marpa_m_object_t_set(Marpa_Tree t)
+  void marpa_m_object_v_set(Marpa_Value v)
+
+  int (*marpa_m_pointer)(const char *method_name)
+  char *marpa_m_error_message (const char *method_name)
+  char *marpa_m_parameter_spec (const char *method_name)
+
+    %s -- Marpa_Symbol_ID
+    %r -- Marpa_Rule_ID
+    %n -- Marpa_Rank
+    int
+    void pointer
+    int pointer
+    Marpa_Event
+    Marpa_Event pointer
+
+  void marpa_m_success_test(const char* name, ...)
+  void marpa_m_failure_test(const char* name, ...)
+
+*/
+
+static int
+marpa_method_test(const char *spec, ...)
+{
+}
+
 int
 main (int argc, char *argv[])
 {

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -230,6 +230,8 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_g_symbol_is_productive", &marpa_g_symbol_is_productive, "%s" },
   { "marpa_g_symbol_is_terminal",  &marpa_g_symbol_is_terminal, "%s" },
   { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
+  { "marpa_g_rule_is_nulling", &marpa_g_rule_is_nulling, "%r" },
+  { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
 };
 
 static Marpa_Method_Spec
@@ -422,11 +424,10 @@ main (int argc, char *argv[])
 
   /* Rules */
   marpa_m_test("marpa_g_rule_is_nullable", g, R_top_2, -2, MARPA_ERR_NOT_PRECOMPUTED);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", MSG_NOT_PRECOMPUTED);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", MSG_NOT_PRECOMPUTED);
-  is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", MSG_NOT_PRECOMPUTED);
+  marpa_m_test("marpa_g_rule_is_nulling", g, R_top_2, -2, MARPA_ERR_NOT_PRECOMPUTED);
+  marpa_m_test("marpa_g_rule_is_loop", g, R_C2_3, -2, MARPA_ERR_NOT_PRECOMPUTED);
 
-  /* expected failures on attempts to non-well-formed and non-existing symbols as terminals */
+  /* expected failures on attempts to invalid and non-existing symbols as terminals */
   is_failure_invalid_symbol_id
     (g, marpa_g_symbol_is_terminal_set (g, -1, 1), "marpa_g_symbol_is_terminal");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_terminal_set (g, 42, 1),

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -237,7 +237,7 @@ marpa_m_method_spec(const char *name)
 
 static char *marpa_m_error_message (Marpa_Error_Code error_code)
 {
-  if ( error_code == MARPA_ERR_NO_START_SYMBOL )   return "no start symbol";
+  if ( error_code == MARPA_ERR_NO_START_SYMBOL ) return "no start symbol";
   if ( error_code == MARPA_ERR_INVALID_SYMBOL_ID ) return "invalid symbol id";
   if ( error_code == MARPA_ERR_NO_SUCH_SYMBOL_ID ) return "no such symbol id";
   return "";
@@ -274,7 +274,7 @@ marpa_m_test(const char* name, ...)
   if (ms.as == "")
   {
     /* dispatch based on what object is set */
-    if (g != NULL)      rv_seen = ms.p(g);
+    if (g != NULL) rv_seen = ms.p(g);
     else if (r != NULL) rv_seen = ms.p(r);
   }
   else
@@ -283,13 +283,13 @@ marpa_m_test(const char* name, ...)
     curr_arg = strtok(tok_buf, " ,-");
     while (curr_arg != NULL)
     {
-      if (strncmp(curr_arg, "%s", 2) == 0)      S_id   = va_arg(args, Marpa_Symbol_ID);
+      if (strncmp(curr_arg, "%s", 2) == 0) S_id   = va_arg(args, Marpa_Symbol_ID);
       else if (strncmp(curr_arg, "%i", 2) == 0) intarg = va_arg(args, int);
 
       curr_arg = strtok(NULL, " ,-");
     }
     /* call marpa method based on signature */
-    if (strcmp(ms.as, "%s") == 0)          rv_seen = ms.p(g, S_id);
+    if (strcmp(ms.as, "%s") == 0) rv_seen = ms.p(g, S_id);
     else if (strcmp(ms.as, "%s, %i") == 0) rv_seen = ms.p(g, S_id, intarg);
   }
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -209,34 +209,39 @@ typedef int (*marpa_m_pointer)();
     ...
 */
 typedef char *marpa_m_argspec;
+typedef char *marpa_m_name;
 
 struct marpa_method_spec {
+  marpa_m_name n;
   marpa_m_pointer p;
   marpa_m_argspec as;
 };
 
 typedef struct marpa_method_spec Marpa_Method_Spec;
 
+#define MAX_METHSPEC 4
+Marpa_Method_Spec methspec[MAX_METHSPEC] = {
+  { "marpa_g_symbol_is_start", &marpa_g_symbol_is_start, "%s" },
+  { "marpa_g_symbol_is_terminal_set", &marpa_g_symbol_is_terminal_set, "%s, %i" },
+  { "marpa_g_start_symbol", &marpa_g_start_symbol, "" },
+  { "marpa_g_highest_symbol_id", &marpa_g_highest_symbol_id, ""}
+};
+
 static Marpa_Method_Spec
 marpa_m_method_spec(const char *name)
 {
   Marpa_Method_Spec ms;
+  int i;
 
-  if ( strcmp(name, "marpa_g_symbol_is_start") == 0 )
-    ms.p = &marpa_g_symbol_is_start,        ms.as = "%s";
-  else if ( strcmp(name, "marpa_g_symbol_is_terminal_set") == 0 )
-    ms.p = &marpa_g_symbol_is_terminal_set, ms.as = "%s, %i";
-  else if ( strcmp(name, "marpa_g_start_symbol") == 0 )
-    ms.p = &marpa_g_start_symbol, ms.as = "";
-  else if ( strcmp(name, "marpa_g_highest_symbol_id") == 0 )
-    ms.p = &marpa_g_highest_symbol_id, ms.as = "";
-  else
+  for (i = 0; i < MAX_METHSPEC; i++)
   {
-    printf("No spec yet for Marpa method %s().\n", name);
-    exit(1);
+    if ( strcmp(name, methspec[i].n ) == 0 )
+    {
+      return methspec[i];
+    }
   }
-
-  return ms;
+  printf("No spec yet for Marpa method %s().\n", name);
+  exit(1);
 }
 
 static char *marpa_m_error_message (Marpa_Error_Code error_code)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -421,7 +421,7 @@ main (int argc, char *argv[])
 
   Marpa_Symbol_ID S_invalid, S_no_such;
   Marpa_Rule_ID R_invalid, R_no_such;
-  Marpa_Rank rank;
+  Marpa_Rank negative_rank, positive_rank;
   int flag;
 
   int reactivate;
@@ -557,17 +557,21 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_g_symbol_is_counted", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
 
   /* Ranks */
-  rank = -2;
-  marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, rank, rank);
-  marpa_m_test("marpa_g_rule_rank", g, R_top_1, rank);
+  negative_rank = -1;
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, negative_rank, negative_rank);
+  marpa_m_test("marpa_g_rule_rank", g, R_top_1, negative_rank);
+
+  positive_rank = 1;
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_2, positive_rank, positive_rank);
+  marpa_m_test("marpa_g_rule_rank", g, R_top_2, positive_rank);
 
   flag = 1;
   marpa_m_test("marpa_g_rule_null_high_set", g, R_top_2, flag, flag);
   marpa_m_test("marpa_g_rule_null_high", g, R_top_2, flag);
 
   /* invalid/no such rule id error handling */
-  marpa_m_test("marpa_g_rule_rank_set", g, R_invalid, rank, -2, MARPA_ERR_INVALID_RULE_ID);
-  marpa_m_test("marpa_g_rule_rank_set", g, R_no_such, rank, -2, MARPA_ERR_NO_SUCH_RULE_ID);
+  marpa_m_test("marpa_g_rule_rank_set", g, R_invalid, positive_rank, -2, MARPA_ERR_INVALID_RULE_ID);
+  marpa_m_test("marpa_g_rule_rank_set", g, R_no_such, negative_rank, -2, MARPA_ERR_NO_SUCH_RULE_ID);
 
   marpa_m_test("marpa_g_rule_rank", g, R_invalid, -2, MARPA_ERR_INVALID_RULE_ID);
   marpa_m_test("marpa_g_rule_rank", g, R_no_such, -2, MARPA_ERR_NO_SUCH_RULE_ID);
@@ -582,8 +586,17 @@ main (int argc, char *argv[])
   ok(1, "precomputation succeeded");
 
   /* Ranks methods on precomputed grammar */
-  marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, rank, -2, MARPA_ERR_PRECOMPUTED);
-  marpa_m_test("marpa_g_rule_rank", g, R_top_1, -2, MARPA_ERR_PRECOMPUTED);
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, negative_rank, -2, MARPA_ERR_PRECOMPUTED);
+  if (marpa_g_rule_rank(g, R_top_1) == negative_rank)
+    if (marpa_g_error(g, NULL) == MARPA_ERR_NONE)
+      ok(1, "marpa_g_rule_rank() returns negative_rank and marpa_g_error() returns MARPA_ERR_NONE");
+    else
+      ok(0, "marpa_g_rule_rank() returns negative_rank and marpa_g_error() returns MARPA_ERR_NONE");
+  else
+    ok(0, "marpa_g_rule_rank() returns negative_rank");
+
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_2, positive_rank, -2, MARPA_ERR_PRECOMPUTED);
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_2, positive_rank);
 
   marpa_m_test("marpa_g_rule_null_high_set", g, R_top_2, flag, -2, MARPA_ERR_PRECOMPUTED);
   marpa_m_test("marpa_g_rule_null_high", g, R_top_2, flag);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -227,17 +227,14 @@ how
   };
   typedef struct marpa_method_spec Marpa_Method_Spec;
 
-  Marpa_Method_Spec marpa_m_method_spec(const char *method_name)
-  char *marpa_m_error_message (Marpa_Error_Code error_code)
-
+  parameter spec
     %s -- Marpa_Symbol_ID
     %r -- Marpa_Rule_ID
     %n -- Marpa_Rank
-    int
-    void pointer
-    int pointer
-    Marpa_Event
-    Marpa_Event pointer
+
+  Marpa_Method_Spec marpa_m_method_spec(const char *method_name)
+
+  char *marpa_m_error_message (Marpa_Error_Code error_code)
 
   void marpa_m_success_test(const char* name, ...)
   void marpa_m_failure_test(const char* name, ...)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -279,6 +279,15 @@ static char *marpa_m_error_message (Marpa_Error_Code error_code)
   exit(1);
 }
 
+/* we need a grammar to call marpa_g_error() */
+static Marpa_Grammar marpa_m_g = NULL;
+
+static int
+marpa_m_grammar_set(Marpa_Grammar g) { marpa_m_g = g; }
+
+static Marpa_Grammar
+marpa_m_grammar() { return marpa_m_g; }
+
 static int
 marpa_m_test(const char* name, ...)
 {
@@ -642,6 +651,8 @@ int marpa_g_symbol_is_prediction_event_set (g, S_top, value)
   if (!rc)
     fail("marpa_r_start_input", g);
 
+  /* */
+  marpa_m_grammar_set(g);
   diag ("at earleme 0");
   marpa_m_test("marpa_r_is_exhausted", r, 1);
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -229,6 +229,7 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_g_symbol_is_nulling", &marpa_g_symbol_is_nulling, "%s" },
   { "marpa_g_symbol_is_productive", &marpa_g_symbol_is_productive, "%s" },
   { "marpa_g_symbol_is_terminal",  &marpa_g_symbol_is_terminal, "%s" },
+  { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
 };
 
 static Marpa_Method_Spec
@@ -288,6 +289,7 @@ marpa_m_test(const char* name, ...)
   Marpa_Recognizer r;
 
   Marpa_Symbol_ID S_id;
+  Marpa_Rule_ID R_id;
   int intarg;
 
   int rv_wanted, rv_seen;
@@ -319,13 +321,15 @@ marpa_m_test(const char* name, ...)
     curr_arg = strtok(tok_buf, " ,-");
     while (curr_arg != NULL)
     {
-      if (strncmp(curr_arg, "%s", 2) == 0) S_id   = va_arg(args, Marpa_Symbol_ID);
+      if (strncmp(curr_arg, "%s", 2) == 0) S_id = va_arg(args, Marpa_Symbol_ID);
+      else if (strncmp(curr_arg, "%r", 2) == 0) R_id   = va_arg(args, Marpa_Rule_ID);
       else if (strncmp(curr_arg, "%i", 2) == 0) intarg = va_arg(args, int);
 
       curr_arg = strtok(NULL, " ,-");
     }
     /* call marpa method based on signature */
     if (strcmp(ms.as, "%s") == 0) rv_seen = ms.p(g, S_id);
+    if (strcmp(ms.as, "%r") == 0) rv_seen = ms.p(g, R_id);
     else if (strcmp(ms.as, "%s, %i") == 0) rv_seen = ms.p(g, S_id, intarg);
   }
 
@@ -417,6 +421,7 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_g_symbol_is_terminal", g, S_top, 0);
 
   /* Rules */
+  marpa_m_test("marpa_g_rule_is_nullable", g, R_top_2, -2, MARPA_ERR_NOT_PRECOMPUTED);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nullable (g, R_top_2), "marpa_g_rule_is_nullable", MSG_NOT_PRECOMPUTED);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_nulling (g, R_top_2), "marpa_g_rule_is_nulling", MSG_NOT_PRECOMPUTED);
   is_failure(g, MARPA_ERR_NOT_PRECOMPUTED, -2, marpa_g_rule_is_loop (g, R_C2_3), "marpa_g_rule_is_loop", MSG_NOT_PRECOMPUTED);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -220,7 +220,7 @@ struct marpa_method_spec {
 typedef struct marpa_method_spec Marpa_Method_Spec;
 
 #define MAX_METHSPEC 4
-Marpa_Method_Spec methspec[MAX_METHSPEC] = {
+const Marpa_Method_Spec methspec[MAX_METHSPEC] = {
   { "marpa_g_symbol_is_start", &marpa_g_symbol_is_start, "%s" },
   { "marpa_g_symbol_is_terminal_set", &marpa_g_symbol_is_terminal_set, "%s, %i" },
   { "marpa_g_start_symbol", &marpa_g_start_symbol, "" },
@@ -244,11 +244,33 @@ marpa_m_method_spec(const char *name)
   exit(1);
 }
 
+typedef char *marpa_m_errmsg;
+struct marpa_m_error {
+  Marpa_Error_Code c;
+  marpa_m_errmsg m;
+};
+
+typedef struct marpa_m_error Marpa_Method_Error;
+
+#define MAX_ERRSPEC 3
+const Marpa_Method_Error errspec[MAX_ERRSPEC] = {
+  { MARPA_ERR_NO_START_SYMBOL, "no start symbol" },
+  { MARPA_ERR_INVALID_SYMBOL_ID, "invalid symbol id" },
+  { MARPA_ERR_NO_SUCH_SYMBOL_ID, "no such symbol id" },
+};
+
 static char *marpa_m_error_message (Marpa_Error_Code error_code)
 {
-  if ( error_code == MARPA_ERR_NO_START_SYMBOL ) return "no start symbol";
-  if ( error_code == MARPA_ERR_INVALID_SYMBOL_ID ) return "invalid symbol id";
-  if ( error_code == MARPA_ERR_NO_SUCH_SYMBOL_ID ) return "no such symbol id";
+  Marpa_Method_Error me;
+  int i;
+
+  for (i = 0; i < MAX_ERRSPEC; i++)
+  {
+    if ( error_code == errspec[i].c )
+    {
+      return errspec[i].m;
+    }
+  }
   printf("No message yet for Marpa error code %d.\n", error_code);
   exit(1);
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -226,9 +226,11 @@ marpa_m_method_spec(const char *name)
     ms.p = &marpa_g_symbol_is_start,        ms.as = "%s";
   else if ( strcmp(name, "marpa_g_symbol_is_terminal_set") == 0 )
     ms.p = &marpa_g_symbol_is_terminal_set, ms.as = "%s, %i";
+  else if ( strcmp(name, "marpa_g_start_symbol") == 0 )
+    ms.p = &marpa_g_start_symbol, ms.as = "";
   else
   {
-    printf("Unknown Marpa method name %s.\n", name);
+    printf("No spec yet for Marpa method %s().\n", name);
     exit(1);
   }
 
@@ -240,7 +242,8 @@ static char *marpa_m_error_message (Marpa_Error_Code error_code)
   if ( error_code == MARPA_ERR_NO_START_SYMBOL ) return "no start symbol";
   if ( error_code == MARPA_ERR_INVALID_SYMBOL_ID ) return "invalid symbol id";
   if ( error_code == MARPA_ERR_NO_SUCH_SYMBOL_ID ) return "no such symbol id";
-  return "";
+  printf("No message yet for Marpa error code %d.\n", error_code);
+  exit(1);
 }
 
 static int
@@ -323,7 +326,7 @@ marpa_m_test(const char* name, ...)
     sprintf(desc_buf, "%s() failed, returned %d", name, rv_seen);
     is_int( rv_wanted, rv_seen, desc_buf );
 
-    sprintf(desc_buf, "%s() erred on %s", name, marpa_m_error_message(err_seen));
+    sprintf(desc_buf, "%s() error: %s", name, marpa_m_error_message(err_seen));
     is_int( err_wanted, err_seen, desc_buf );
   }
 
@@ -361,6 +364,7 @@ main (int argc, char *argv[])
   /* Returns 0 if sym_id is not the start symbol, either because the start symbol
      is different from sym_id, or because the start symbol has not been set yet. */
   marpa_m_test("marpa_g_symbol_is_start", g, S_top, 0);
+  marpa_m_test("marpa_g_start_symbol", g, -1, MARPA_ERR_NO_START_SYMBOL);
   is_failure(g, MARPA_ERR_NO_START_SYMBOL, -1, marpa_g_start_symbol (g), "marpa_g_start_symbol", MARPA_TEST_MSG_NO_START_SYMBOL);
 
   (marpa_g_start_symbol_set (g, S_top) >= 0)

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -218,11 +218,15 @@ struct marpa_method_spec {
 typedef struct marpa_method_spec Marpa_Method_Spec;
 
 static Marpa_Method_Spec
-marpa_m_method_spec(const char *method_name)
+marpa_m_method_spec(const char *name)
 {
   Marpa_Method_Spec ms;
-  if ( strcmp(method_name, "marpa_g_symbol_is_start") == 0 ){
+  if ( strcmp(name, "marpa_g_symbol_is_start") == 0 ){
     ms.p = &marpa_g_symbol_is_start, ms.s = "%s";
+  }
+  else{
+    printf("Unknown Marpa method name %.\n", name);
+    exit(1);
   }
   return ms;
 }
@@ -242,21 +246,21 @@ marpa_m_success_test(const char* name, ...)
   Marpa_Symbol_ID S_id;
 
   ms = marpa_m_method_spec(name);
+
   va_list args;
   va_start(args, name);
 
   if (strncmp(name, "marpa_g_", 8) == 0)
   {
     g = va_arg(args, Marpa_Grammar);
-
     if (strcmp(ms.s, "%s") == 0)
+    {
       S_id = va_arg(args, Marpa_Symbol_ID);
-
-    is_int( va_arg(args, int), ms.p(g, S_id), name);
+      is_int( va_arg(args, int), ms.p(g, S_id), name);
+    }
   }
 
   va_end(args);
-
 }
 
 static int

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -173,6 +173,19 @@ is_failure(Marpa_Grammar g, Marpa_Error_Code errcode_wanted, int retcode_wanted,
   marpa_g_error_clear(g);
 }
 
+/* check that method_name returned -2 and
+   error code is set to MARPA_ERR_INVALID_SYMBOL_ID
+   */
+#define MARPA_TEST_MSG_NO_START_SYMBOL "fail before marpa_g_start_symbol_set()"
+#define MARPA_TEST_MSG_INVALID_SYMBOL_ID "malformed symbol id"
+#define MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID "invalid symbol id"
+static int
+is_failure_invalid_symbol_id(Marpa_Grammar g, int retcode, char *method_name)
+{
+  return is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, retcode, method_name,
+    MARPA_TEST_MSG_INVALID_SYMBOL_ID);
+}
+
 /* test retval and print error code on unexpected failure */
 static int
 is_success(Marpa_Grammar g, int wanted, int retval, char *method_name)
@@ -206,12 +219,7 @@ main (int argc, char *argv[])
   /* Grammar Methods per sections of api.texi: Symbols, Rules, Sequnces, Ranks, Events */
 
   /* these must soft fail if there is not start symbol */
-#define MARPA_TEST_MSG_NO_START_SYMBOL "fail before marpa_g_start_symbol_set()"
-#define MARPA_TEST_MSG_INVALID_SYMBOL_ID "malformed symbol id"
-#define MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID "invalid symbol id"
-
-  is_failure(g, MARPA_ERR_INVALID_SYMBOL_ID, -2, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start",
-    MARPA_TEST_MSG_INVALID_SYMBOL_ID);
+  is_failure_invalid_symbol_id(g, marpa_g_symbol_is_start (g, -1), "marpa_g_symbol_is_start");
   is_failure(g, MARPA_ERR_NO_SUCH_SYMBOL_ID, -1, marpa_g_symbol_is_start (g, 42), "marpa_g_symbol_is_start",
     MARPA_TEST_MSG_NO_SUCH_SYMBOL_ID);
   /* Returns 0 if sym_id is not the start symbol, either because the start symbol

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -257,6 +257,9 @@ main (int argc, char *argv[])
   Marpa_Rank rank;
   int flag;
 
+  int reactivate;
+  int value;
+
   plan_lazy();
 
   marpa_c_init (&marpa_configuration);
@@ -429,9 +432,36 @@ main (int argc, char *argv[])
   /* Events */
   /* test that attempts to create events, other than nulled events,
      results in a reasonable error -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111838 */
+/*
+
+reactivate = 1;
+reactivate = 0;
+int marpa_g_completion_symbol_activate (g, S_top, reactivate )
+int marpa_g_prediction_symbol_activate (g, S_top, reactivate )
+
+// If the active status of the completion event for sym_id cannot be set as
+// indicated by reactivate, the method fails. On failure, -2 is returned.
+
+value = 1;
+int marpa_g_symbol_is_completion_event (g, S_top)
+int marpa_g_symbol_is_completion_event_set ( g, S_top, value)
+
+int marpa_g_symbol_is_prediction_event (g, S_top)
+int marpa_g_symbol_is_prediction_event_set (g, S_top, value)
+
+// On success, 1 if symbol sym_id is an event symbol after the call, 0 otherwise.
+// If sym_id is well-formed, but there is no such symbol, -1.
+
+// malformed/invalid symbols
+
+*/
 
   trivial_grammar_precompute(g, S_top);
   ok(1, "precomputation succeeded");
+
+  /* event methods after precomputation
+     if the grammar g is precomputed; or on other failure, -2.
+   */
 
   /* Recognizer Methods */
   r = marpa_r_new (g);

--- a/work/dev/marpa.w
+++ b/work/dev/marpa.w
@@ -2637,7 +2637,11 @@ int marpa_g_sequence_min(
     @<Fail if |xrl_id| is malformed@>@;
     @<Fail if |xrl_id| does not exist@>@;
     xrl = XRL_by_ID(xrl_id);
-    if (!XRL_is_Sequence(xrl)) return -1;
+    if (!XRL_is_Sequence(xrl))
+      {
+        MARPA_ERROR (MARPA_ERR_NOT_A_SEQUENCE);
+        return -1;
+      }
     return Minimum_of_XRL(xrl);
 }
 


### PR DESCRIPTION
I was having a hard time coping with that spaghetti code I wrote in trivial1.c, so before proceeding with other methods rewritten the testing code to use `va_list()` and method/error spec tables that allowed much cleaner test calls and can be used in further testing of marpa methods if needed. The test interface (marpa_m_* for Marpa method) is:

```c
marpa_m_test(method_name, method_arg1, method_arg2, ...,  
  expected_return_value); // for success
marpa_m_test(method_name, method_arg1, method_arg2, ..., 
  expected_return_value, expected error_code); // for failure
```

Some issues:

`marpa_g_sequence_min()` didn't set `MARPA_ERR_NOT_A_SEQUENCE` correctly, so I've attempted a fix -- 2d35645

I take it `marpa_g_rule_rank()` should succeed on a precomputed grammar, but it fails on negative ranks, because `marpa_g_error()` doesn't return `MARPA_ERR_NONE`.

`marpa_g_rule_null_high()` succeeds. The doc says: "If the grammar has been precomputed, -2.", so the test fail by requiring `-2, MARPA_ERR_PRECOMPUTED` as return value and error code.