### PR TITLE
method census: Events, Life cycle mutators, and Location Accessors

### DIFF
--- a/test/TESTS
+++ b/test/TESTS
@@ -1,3 +1,4 @@
 simple/rule1
 simple/trivial
 simple/trivial1
+simple/nits

--- a/test/simple/CMakeLists.txt
+++ b/test/simple/CMakeLists.txt
@@ -13,8 +13,12 @@ target_link_libraries(trivial ${LIBMARPA_STATIC} ${LIBTAP})
 add_executable(trivial1 trivial1.c marpa_test.c)
 target_link_libraries(trivial1 ${LIBMARPA_STATIC} ${LIBTAP})
 
+add_executable(nits nits.c marpa_test.c)
+target_link_libraries(nits ${LIBMARPA_STATIC} ${LIBTAP})
+
 add_test(rule1 rule1)
 add_test(trivial trivial)
 add_test(trivial1 trivial1)
+add_test(nits nits)
 
 # vim: expandtab shiftwidth=4:

--- a/test/simple/CMakeLists.txt
+++ b/test/simple/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(rule1 ${LIBMARPA_STATIC} ${LIBTAP})
 add_executable(trivial trivial.c)
 target_link_libraries(trivial ${LIBMARPA_STATIC} ${LIBTAP})
 
-add_executable(trivial1 trivial1.c)
+add_executable(trivial1 trivial1.c marpa_test.c)
 target_link_libraries(trivial1 ${LIBMARPA_STATIC} ${LIBTAP})
 
 add_test(rule1 rule1)

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -19,6 +19,9 @@
 
 #include "marpa_test.h"
 
+Marpa_Symbol_ID S_invalid = -1, S_no_such = 42;
+Marpa_Rule_ID R_invalid = -1, R_no_such = 42;
+
 /* For (error) messages */
 static char msgbuf[80];
 

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -131,7 +131,7 @@ Marpa_Grammar
 marpa_m_grammar() { return marpa_m_g; }
 
 int
-marpa_m_test(const char* name, ...)
+marpa_m_test_func(const char* name, ...)
 {
   Marpa_Method_Spec ms;
 

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -82,6 +82,11 @@ const Marpa_Method_Spec methspec[] = {
 
   { "marpa_r_alternative", &marpa_r_alternative, "%s, %i, %i" },
   { "marpa_r_earleme_complete", &marpa_r_earleme_complete, "" },
+  { "marpa_r_current_earleme", (marpa_m_pointer)&marpa_r_current_earleme, "" },
+  { "marpa_r_furthest_earleme", (marpa_m_pointer)&marpa_r_furthest_earleme, "" },
+  { "marpa_r_latest_earley_set", &marpa_r_latest_earley_set, "" },
+  { "marpa_r_earleme", &marpa_r_earleme, "%i" },
+  { "marpa_r_earley_set_value", &marpa_r_earley_set_value, "%i" },
 
 };
 
@@ -111,6 +116,7 @@ const Marpa_Method_Error errspec[] = {
   { MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "recce not accepting input" },
   { MARPA_ERR_TOKEN_LENGTH_LE_ZERO, "token length less than zero" },
   { MARPA_ERR_PARSE_EXHAUSTED, "parse exhausted" },
+  { MARPA_ERR_NO_EARLEY_SET_AT_LOCATION, "no earley set at location" },
 };
 
 char *marpa_m_error_message (Marpa_Error_Code error_code)
@@ -180,6 +186,10 @@ marpa_m_test_func(const char* name, ...)
       if (intarg == ARG_UNDEF) intarg = va_arg(args, int);
       else if (intarg1 == ARG_UNDEF) intarg1 = va_arg(args, int);
     }
+    else{
+      printf("No variable yet for argument spec %s.\n", curr_arg);
+      exit(1);
+    }
 
     curr_arg = strtok(NULL, " ,-");
     curr_arg_ix++;
@@ -187,6 +197,7 @@ marpa_m_test_func(const char* name, ...)
 
   /* call marpa method based on argspec */
   if (ms.as == "") rv_seen = ms.p(marpa_m_object);
+  else if (strcmp(ms.as, "%i") == 0) rv_seen = ms.p(marpa_m_object, intarg);
   else if (strcmp(ms.as, "%s") == 0) rv_seen = ms.p(marpa_m_object, S_id);
   else if (strcmp(ms.as, "%r") == 0) rv_seen = ms.p(marpa_m_object, R_id);
   else if (strcmp(ms.as, "%s, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, intarg);

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -231,8 +231,8 @@ marpa_m_test_func(const char* name, ...)
       snprintf(msgbuf, MARPA_M_MSGBUF_LEN, "%s() succeeded", name);
       is_int( rv_wanted, rv_seen, msgbuf );
     }
-  /* failure wanted */
-  else
+  /* failure wanted, except if it marks arguments end */
+  else if (rv_wanted != ARGS_END)
   {
     /* return value */
     err_wanted = va_arg(args, int);

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -109,9 +109,11 @@ const Marpa_Method_Error errspec[] = {
   { MARPA_ERR_INVALID_RULE_ID, "invalid rule id" },
   { MARPA_ERR_NO_SUCH_RULE_ID, "no such rule id" },
   { MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "recce not accepting input" },
+  { MARPA_ERR_TOKEN_LENGTH_LE_ZERO, "token length less than zero" },
+  { MARPA_ERR_PARSE_EXHAUSTED, "parse exhausted" },
 };
 
-static char *marpa_m_error_message (Marpa_Error_Code error_code)
+char *marpa_m_error_message (Marpa_Error_Code error_code)
 {
   int i;
   for (i = 0; i < sizeof(errspec) / sizeof(Marpa_Method_Error); i++)

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2015 Jeffrey Kegler
+ * This file is part of Libmarpa.  Libmarpa is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Libmarpa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser
+ * General Public License along with Libmarpa.  If not, see
+ * http://www.gnu.org/licenses/.
+ */
+
+/* Libmarpa method test interface -- marpa_m_test */
+
+#include "marpa_test.h"
+
+/* For (error) messages */
+static char msgbuf[80];
+
+const Marpa_Method_Spec methspec[] = {
+
+  { "marpa_g_start_symbol_set", &marpa_g_start_symbol_set, "%s" },
+  { "marpa_g_symbol_is_start", &marpa_g_symbol_is_start, "%s" },
+  { "marpa_g_start_symbol", &marpa_g_start_symbol, "" },
+
+  { "marpa_g_symbol_is_terminal_set", &marpa_g_symbol_is_terminal_set, "%s, %i" },
+  { "marpa_g_symbol_is_terminal",  &marpa_g_symbol_is_terminal, "%s" },
+
+  { "marpa_g_highest_symbol_id", &marpa_g_highest_symbol_id, ""},
+
+  { "marpa_g_symbol_is_accessible", &marpa_g_symbol_is_accessible, "%s" },
+  { "marpa_g_symbol_is_nullable", &marpa_g_symbol_is_nullable, "%s" },
+  { "marpa_g_symbol_is_nulling", &marpa_g_symbol_is_nulling, "%s" },
+  { "marpa_g_symbol_is_productive", &marpa_g_symbol_is_productive, "%s" },
+
+  { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
+  { "marpa_g_rule_is_nulling", &marpa_g_rule_is_nulling, "%r" },
+  { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
+
+  { "marpa_g_precompute", &marpa_g_precompute, "" },
+
+  { "marpa_g_highest_rule_id", &marpa_g_highest_rule_id, "" },
+  { "marpa_g_rule_is_accessible", &marpa_g_rule_is_accessible, "%r" },
+  { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
+  { "marpa_g_rule_is_nulling", &marpa_g_rule_is_nulling, "%r" },
+  { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
+  { "marpa_g_rule_is_productive", &marpa_g_rule_is_productive, "%r" },
+  { "marpa_g_rule_length", &marpa_g_rule_length, "%r" },
+  { "marpa_g_rule_lhs", &marpa_g_rule_lhs, "%r" },
+  { "marpa_g_rule_rhs", &marpa_g_rule_rhs, "%r, %i" },
+
+  { "marpa_g_sequence_new", &marpa_g_sequence_new, "%s, %s, %s, %i, %i" },
+  { "marpa_g_rule_is_proper_separation", &marpa_g_rule_is_proper_separation, "%r" },
+  { "marpa_g_sequence_min", &marpa_g_sequence_min, "%r" },
+  { "marpa_g_sequence_separator", &marpa_g_sequence_separator, "%r" },
+  { "marpa_g_symbol_is_counted", &marpa_g_symbol_is_counted, "%s" },
+
+  { "marpa_g_rule_rank_set", &marpa_g_rule_rank_set, "%r, %i" },
+  { "marpa_g_rule_rank", &marpa_g_rule_rank, "%r" },
+  { "marpa_g_rule_null_high_set", &marpa_g_rule_null_high_set, "%r, %i" },
+  { "marpa_g_rule_null_high", &marpa_g_rule_null_high, "%r" },
+
+  { "marpa_g_symbol_is_completion_event_set", &marpa_g_symbol_is_completion_event_set, "%s, %i" },
+  { "marpa_g_symbol_is_completion_event", &marpa_g_symbol_is_completion_event, "%s" },
+  { "marpa_g_completion_symbol_activate", &marpa_g_completion_symbol_activate, "%s, %i" },
+
+  { "marpa_g_symbol_is_prediction_event_set", &marpa_g_symbol_is_prediction_event_set, "%s, %i" },
+  { "marpa_g_symbol_is_prediction_event", &marpa_g_symbol_is_prediction_event, "%s" },
+  { "marpa_g_prediction_symbol_activate", &marpa_g_prediction_symbol_activate, "%s, %i" },
+
+  { "marpa_r_expected_symbol_event_set", &marpa_r_expected_symbol_event_set, "%s, %i" },
+  { "marpa_r_is_exhausted", &marpa_r_is_exhausted, "" },
+
+  { "marpa_r_alternative", &marpa_r_alternative, "%s, %i, %i" },
+  { "marpa_r_earleme_complete", &marpa_r_earleme_complete, "" },
+
+};
+
+static Marpa_Method_Spec
+marpa_m_method_spec(const char *name)
+{
+  int i;
+  for (i = 0; i < sizeof(methspec) / sizeof(Marpa_Method_Spec); i++)
+    if ( strcmp(name, methspec[i].n ) == 0 )
+      return methspec[i];
+  printf("No spec yet for Marpa method %s().\n", name);
+  exit(1);
+}
+
+const Marpa_Method_Error errspec[] = {
+  { MARPA_ERR_NO_START_SYMBOL, "no start symbol" },
+  { MARPA_ERR_INVALID_SYMBOL_ID, "invalid symbol id" },
+  { MARPA_ERR_NO_SUCH_SYMBOL_ID, "no such symbol id" },
+  { MARPA_ERR_NOT_PRECOMPUTED, "grammar not precomputed" },
+  { MARPA_ERR_TERMINAL_IS_LOCKED, "terminal locked" },
+  { MARPA_ERR_NULLING_TERMINAL, "nulling terminal" },
+  { MARPA_ERR_PRECOMPUTED, "grammar precomputed" },
+  { MARPA_ERR_SEQUENCE_LHS_NOT_UNIQUE, "sequence lhs not unique" },
+  { MARPA_ERR_NOT_A_SEQUENCE, "not a sequence rule" },
+  { MARPA_ERR_INVALID_RULE_ID, "invalid rule id" },
+  { MARPA_ERR_NO_SUCH_RULE_ID, "no such rule id" },
+  { MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "recce not accepting input" },
+};
+
+static char *marpa_m_error_message (Marpa_Error_Code error_code)
+{
+  int i;
+  for (i = 0; i < sizeof(errspec) / sizeof(Marpa_Method_Error); i++)
+    if ( error_code == errspec[i].c )
+      return errspec[i].m;
+  printf("No message yet for Marpa error code %d.\n", error_code);
+  exit(1);
+}
+
+/* we need a grammar to call marpa_g_error() */
+static Marpa_Grammar marpa_m_g = NULL;
+
+int
+marpa_m_grammar_set(Marpa_Grammar g) { marpa_m_g = g; }
+
+Marpa_Grammar
+marpa_m_grammar() { return marpa_m_g; }
+
+int
+marpa_m_test(const char* name, ...)
+{
+  Marpa_Method_Spec ms;
+
+  Marpa_Grammar g;
+  Marpa_Recognizer r;
+
+  Marpa_Symbol_ID S_id, S_id1, S_id2;
+  Marpa_Rule_ID R_id;
+  int intarg, intarg1;
+
+  int rv_wanted, rv_seen;
+  int err_wanted, err_seen;
+
+  char tok_buf[32];  /* strtok() */
+  char desc_buf[80]; /* test description  */
+  char *curr_arg;
+  int curr_arg_ix;
+
+  ms = marpa_m_method_spec(name);
+
+  va_list args;
+  va_start(args, name);
+
+  g = marpa_m_grammar();
+
+  void *marpa_m_object = va_arg(args, void*);
+
+#define ARG_UNDEF 42424242
+  R_id = S_id = S_id1 = S_id2 = intarg = intarg1 = ARG_UNDEF;
+  strcpy( tok_buf, ms.as );
+  curr_arg = strtok(tok_buf, " ,-");
+  while (curr_arg != NULL)
+  {
+    if (strncmp(curr_arg, "%s", 2) == 0){
+      if (S_id == ARG_UNDEF) S_id = va_arg(args, Marpa_Symbol_ID);
+      else if (S_id1 == ARG_UNDEF) S_id1 = va_arg(args, Marpa_Symbol_ID);
+      else if (S_id2 == ARG_UNDEF) S_id2 = va_arg(args, Marpa_Symbol_ID);
+    }
+    else if (strncmp(curr_arg, "%r", 2) == 0)
+    {
+      R_id   = va_arg(args, Marpa_Rule_ID);
+    }
+    else if (strncmp(curr_arg, "%i", 2) == 0)
+    {
+      if (intarg == ARG_UNDEF) intarg = va_arg(args, int);
+      else if (intarg1 == ARG_UNDEF) intarg1 = va_arg(args, int);
+    }
+
+    curr_arg = strtok(NULL, " ,-");
+    curr_arg_ix++;
+  }
+
+  /* call marpa method based on argspec */
+  if (ms.as == "") rv_seen = ms.p(marpa_m_object);
+  else if (strcmp(ms.as, "%s") == 0) rv_seen = ms.p(marpa_m_object, S_id);
+  else if (strcmp(ms.as, "%r") == 0) rv_seen = ms.p(marpa_m_object, R_id);
+  else if (strcmp(ms.as, "%s, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, intarg);
+  else if (strcmp(ms.as, "%s, %i, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, intarg, intarg1);
+  else if (strcmp(ms.as, "%r, %i") == 0) rv_seen = ms.p(marpa_m_object, R_id, intarg);
+  else if (strcmp(ms.as, "%s, %s, %s, %i, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, S_id1, S_id2, intarg, intarg1);
+  else
+  {
+    printf("No method yet for argument spec %s.\n", ms.as);
+    exit(1);
+  }
+
+  rv_wanted = va_arg(args, int);
+
+  /* success wanted */
+  if ( rv_wanted >= 0 )
+  {
+    /* failure seen */
+    if ( rv_seen < 0 )
+    {
+      sprintf(msgbuf, "%s() unexpectedly returned %d.", name, rv_seen);
+      ok(0, msgbuf);
+    }
+    /* success seen */
+    else {
+      sprintf(desc_buf, "%s()", name);
+      is_int( rv_wanted, rv_seen, desc_buf );
+    }
+  }
+  /* marpa_g_rule_rank() and marpa_g_rule_rank_set() may return negative values,
+     but they are actually ranks if marpa_g_error() returns MARPA_ERR_NONE.
+     So, we don't count them as failures. */
+  else if ( strncmp( name, "marpa_g_rule_rank", 17 ) == 0
+              && marpa_g_error(g, NULL) == MARPA_ERR_NONE )
+    {
+      sprintf(desc_buf, "%s() succeeded", name);
+      is_int( rv_wanted, rv_seen, desc_buf );
+    }
+  /* failure wanted */
+  else
+  {
+    /* return value */
+    err_wanted = va_arg(args, int);
+    sprintf(desc_buf, "%s() failed, returned %d", name, rv_seen);
+    is_int( rv_wanted, rv_seen, desc_buf );
+
+    /* error code */
+    err_seen = marpa_g_error(g, NULL);
+
+    if (err_seen == MARPA_ERR_NONE && rv_seen < 0)
+    {
+      sprintf(msgbuf, "%s(): marpa_g_error() returned MARPA_ERR_NONE, but return value was %d.", name, rv_seen);
+      ok(0, msgbuf);
+    }
+    /* test error code */
+    else
+    {
+      sprintf(desc_buf, "%s() error is: %s", name, marpa_m_error_message(err_seen));
+      is_int( err_wanted, err_seen, desc_buf );
+    }
+  }
+
+  va_end(args);
+}

--- a/test/simple/marpa_test.h
+++ b/test/simple/marpa_test.h
@@ -62,7 +62,6 @@ int marpa_m_grammar_set(Marpa_Grammar g);
 Marpa_Grammar marpa_m_grammar();
 
 char *marpa_m_error_message (Marpa_Error_Code error_code);
-
-#define ARGS_END (uintptr_t)42424242
+#define ARGS_END (uintptr_t)-42424242
 #define marpa_m_test(name, ...)  marpa_m_test_func(name, ##__VA_ARGS__, (ARGS_END))
 int marpa_m_test_func(const char* name, ...);

--- a/test/simple/marpa_test.h
+++ b/test/simple/marpa_test.h
@@ -60,4 +60,6 @@ extern const Marpa_Method_Error errspec[];
 
 int marpa_m_grammar_set(Marpa_Grammar g);
 Marpa_Grammar marpa_m_grammar();
-int marpa_m_test(const char* name, ...);
+#define ARGS_END (uintptr_t)42424242
+#define marpa_m_test(name, ...)  marpa_m_test_func(name, ##__VA_ARGS__, (ARGS_END))
+int marpa_m_test_func(const char* name, ...);

--- a/test/simple/marpa_test.h
+++ b/test/simple/marpa_test.h
@@ -60,6 +60,9 @@ extern const Marpa_Method_Error errspec[];
 
 int marpa_m_grammar_set(Marpa_Grammar g);
 Marpa_Grammar marpa_m_grammar();
+
+char *marpa_m_error_message (Marpa_Error_Code error_code);
+
 #define ARGS_END (uintptr_t)42424242
 #define marpa_m_test(name, ...)  marpa_m_test_func(name, ##__VA_ARGS__, (ARGS_END))
 int marpa_m_test_func(const char* name, ...);

--- a/test/simple/marpa_test.h
+++ b/test/simple/marpa_test.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 Jeffrey Kegler
+ * This file is part of Libmarpa.  Libmarpa is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Libmarpa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser
+ * General Public License along with Libmarpa.  If not, see
+ * http://www.gnu.org/licenses/.
+ */
+
+/* Libmarpa method test interface -- marpa_m_test */
+
+#include <stdio.h>
+#include "marpa.h"
+
+#include "tap/basic.h"
+
+/* Marpa method test interface */
+
+typedef int (*marpa_m_pointer)();
+
+/*
+    %s -- Marpa_Symbol_ID
+    %r -- Marpa_Rule_ID
+    %n -- Marpa_Rank
+    ...
+*/
+typedef char *marpa_m_argspec;
+typedef char *marpa_m_name;
+
+struct marpa_method_spec {
+  marpa_m_name n;
+  marpa_m_pointer p;
+  marpa_m_argspec as;
+};
+
+typedef struct marpa_method_spec Marpa_Method_Spec;
+
+extern const Marpa_Method_Spec methspec[];
+
+typedef char *marpa_m_errmsg;
+struct marpa_m_error {
+  Marpa_Error_Code c;
+  marpa_m_errmsg m;
+};
+
+typedef struct marpa_m_error Marpa_Method_Error;
+
+extern const Marpa_Method_Error errspec[];
+
+int marpa_m_grammar_set(Marpa_Grammar g);
+Marpa_Grammar marpa_m_grammar();
+int marpa_m_test(const char* name, ...);

--- a/test/simple/marpa_test.h
+++ b/test/simple/marpa_test.h
@@ -22,6 +22,9 @@
 
 #include "tap/basic.h"
 
+extern Marpa_Symbol_ID S_invalid, S_no_such;
+extern Marpa_Rule_ID R_invalid, R_no_such;
+
 /* Marpa method test interface */
 
 typedef int (*marpa_m_pointer)();

--- a/test/simple/nits.c
+++ b/test/simple/nits.c
@@ -156,23 +156,21 @@ main (int argc, char *argv[])
   if (!r)
     fail("marpa_r_new", g);
 
-  diag ("The below test is before marpa_r_start_input()");
   Marpa_Symbol_ID S_token = S_A2;
-  marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+  marpa_m_test("marpa_r_alternative", r, S_token, 0, 0,
+    MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "before marpa_r_start_input()");
 
   rc = marpa_r_start_input (r);
   if (!rc)
     fail("marpa_r_start_input", g);
-
-  diag ("The below recce tests are at earleme 0");
 
   Marpa_Symbol_ID S_expected = S_A2;
   int value = 1;
   marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
 
   /* recognizer reading methods */
-  marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID);
-  marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+  marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID, "invalid token symbol");
+  marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID, "no such token symbol");
   marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
   marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
 

--- a/test/simple/nits.c
+++ b/test/simple/nits.c
@@ -170,7 +170,7 @@ main (int argc, char *argv[])
 
   /* recognizer reading methods */
   marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID,
-    "invalid token symbol");
+    "invalid token symbol is checked before no-such");
   marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID,
     "no such token symbol");
   marpa_m_test("marpa_r_alternative", r, S_token, 0, 0,

--- a/test/simple/nits.c
+++ b/test/simple/nits.c
@@ -169,10 +169,13 @@ main (int argc, char *argv[])
   marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
 
   /* recognizer reading methods */
-  marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID, "invalid token symbol");
-  marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID, "no such token symbol");
-  marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
-  marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+  marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID,
+    "invalid token symbol");
+  marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID,
+    "no such token symbol");
+  marpa_m_test("marpa_r_alternative", r, S_token, 0, 0,
+    MARPA_ERR_TOKEN_LENGTH_LE_ZERO, marpa_m_error_message(MARPA_ERR_TOKEN_LENGTH_LE_ZERO));
+  marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_PARSE_EXHAUSTED);
 
   return 0;
 }

--- a/test/simple/nits.c
+++ b/test/simple/nits.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2015 Jeffrey Kegler
+ * This file is part of Libmarpa.  Libmarpa is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * Libmarpa is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser
+ * General Public License along with Libmarpa.  If not, see
+ * http://www.gnu.org/licenses/.
+ */
+
+/* Tests of Libmarpa methods on trivial grammar that is not merely nulling */
+
+#include <stdio.h>
+#include "marpa.h"
+
+#include "marpa_test.h"
+
+static int
+warn (const char *s, Marpa_Grammar g)
+{
+  printf ("%s returned %d\n", s, marpa_g_error (g, NULL));
+}
+
+static int
+fail (const char *s, Marpa_Grammar g)
+{
+  warn (s, g);
+  exit (1);
+}
+
+Marpa_Symbol_ID S_top;
+Marpa_Symbol_ID S_A1;
+Marpa_Symbol_ID S_A2;
+Marpa_Symbol_ID S_B1;
+Marpa_Symbol_ID S_B2;
+Marpa_Symbol_ID S_C1;
+Marpa_Symbol_ID S_C2;
+
+/* Longest rule is <= 4 symbols */
+Marpa_Symbol_ID rhs[4];
+
+Marpa_Rule_ID R_top_1;
+Marpa_Rule_ID R_top_2;
+Marpa_Rule_ID R_C2_3; // highest rule id
+
+/* For (error) messages */
+char msgbuf[80];
+
+char *
+symbol_name (Marpa_Symbol_ID id)
+{
+  if (id == S_top) return "top";
+  if (id == S_A1) return "A1";
+  if (id == S_A2) return "A2";
+  if (id == S_B1) return "B1";
+  if (id == S_B2) return "B2";
+  if (id == S_C1) return "C1";
+  if (id == S_C2) return "C2";
+  sprintf (msgbuf, "no such symbol: %d", id);
+  return msgbuf;
+}
+
+static Marpa_Grammar
+marpa_g_simple_new(Marpa_Config *config)
+{
+  Marpa_Grammar g;
+  g = marpa_g_new (config);
+  if (!g)
+    {
+      Marpa_Error_Code errcode = marpa_c_error (config, NULL);
+      printf ("marpa_g_new returned %d", errcode);
+      exit (1);
+    }
+
+  ((S_top = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+  ((S_A1 = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+  ((S_A2 = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+  ((S_B1 = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+  ((S_B2 = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+  ((S_C1 = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+  ((S_C2 = marpa_g_symbol_new (g)) >= 0)
+    || fail ("marpa_g_symbol_new", g);
+
+  rhs[0] = S_A1;
+  ((R_top_1 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
+    || fail ("marpa_g_rule_new", g);
+  rhs[0] = S_A2;
+  ((R_top_2 = marpa_g_rule_new (g, S_top, rhs, 1)) >= 0)
+    || fail ("marpa_g_rule_new", g);
+  rhs[0] = S_B1;
+  (marpa_g_rule_new (g, S_A1, rhs, 1) >= 0)
+    || fail ("marpa_g_rule_new", g);
+  rhs[0] = S_B2;
+  (marpa_g_rule_new (g, S_A2, rhs, 1) >= 0)
+    || fail ("marpa_g_rule_new", g);
+  rhs[0] = S_C1;
+  (marpa_g_rule_new (g, S_B1, rhs, 1) >= 0)
+    || fail ("marpa_g_rule_new", g);
+  rhs[0] = S_C2;
+  (marpa_g_rule_new (g, S_B2, rhs, 1) >= 0)
+    || fail ("marpa_g_rule_new", g);
+
+  return g;
+}
+
+static Marpa_Error_Code
+marpa_g_simple_precompute(Marpa_Grammar g, Marpa_Symbol_ID S_start)
+{
+  Marpa_Error_Code rc;
+
+  (marpa_g_start_symbol_set (g, S_start) >= 0)
+    || fail ("marpa_g_start_symbol_set", g);
+
+  rc = marpa_g_precompute (g);
+  if (rc < 0)
+    fail("marpa_g_precompute", g);
+
+  return rc;
+}
+
+int
+main (int argc, char *argv[])
+{
+  int rc;
+
+  Marpa_Config marpa_configuration;
+
+  Marpa_Grammar g;
+  Marpa_Recognizer r;
+
+  plan_lazy();
+
+  marpa_c_init (&marpa_configuration);
+  g = marpa_g_simple_new(&marpa_configuration);
+
+  /* for marpa_g_error() in marpa_m_test() */
+  marpa_m_grammar_set(g);
+
+  marpa_g_simple_precompute(g, S_top);
+  ok(1, "precomputation succeeded");
+
+  r = marpa_r_new (g);
+  if (!r)
+    fail("marpa_r_new", g);
+
+  diag ("The below test is before marpa_r_start_input()");
+  Marpa_Symbol_ID S_token = S_A2;
+  marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+
+  rc = marpa_r_start_input (r);
+  if (!rc)
+    fail("marpa_r_start_input", g);
+
+  diag ("The below recce tests are at earleme 0");
+
+  Marpa_Symbol_ID S_expected = S_A2;
+  int value = 1;
+  marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
+
+  /* recognizer reading methods */
+  marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID);
+  marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+  marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+  marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+
+  return 0;
+}

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -430,9 +430,6 @@ main (int argc, char *argv[])
     if (!r)
       fail("marpa_r_new", g);
 
-    Marpa_Symbol_ID S_token = S_A2;
-    marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
-
     rc = marpa_r_start_input (r);
     if (!rc)
       fail("marpa_r_start_input", g);
@@ -444,9 +441,13 @@ main (int argc, char *argv[])
     marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
 
     /* recognizer reading methods */
-    marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID);
-    marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID);
-    marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+    Marpa_Symbol_ID S_token = S_A2;
+    marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0,
+      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input is checked before invalid symbol");
+    marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0,
+      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input is checked before no such symbol");
+    marpa_m_test("marpa_r_alternative", r, S_token, 0, 0,
+      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input");
     marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
 
     { /* event loop -- just count events so far -- there must be no event except exhausted */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -497,9 +497,14 @@ main (int argc, char *argv[])
 
       marpa_m_test("marpa_r_latest_earley_set", r, furthest_earleme);
 
-      marpa_m_test("marpa_r_earleme", r, current_earleme, -2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION);
+//      marpa_m_test("marpa_r_earleme", r, current_earleme, -2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION);
 
     }
+
+    marpa_r_earleme(r, 0);
+    diag("about to call marpa_r_earley_set_value(r, 0) after marpa_r_earleme(r, 0)");
+    marpa_r_earley_set_value (r, 0);
+
   } /* recce method tests */
 
   return 0;

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -699,5 +699,36 @@ main (int argc, char *argv[])
   diag ("at earleme 0");
   marpa_m_test("marpa_r_is_exhausted", r, 1);
 
+  {
+    Marpa_Event event;
+    int exhausted_event_triggered = 0;
+    int spurious_events = 0;
+    int prediction_events = 0;
+    int completion_events = 0;
+    int event_ix;
+    const int event_count = marpa_g_event_count (g);
+
+    is_int(1, event_count, "event count at earleme 0 is %ld", (long) event_count);
+
+    for (event_ix = 0; event_ix < event_count; event_ix++)
+    {
+      int event_type = marpa_g_event (g, &event, event_ix);
+      if (event_type == MARPA_EVENT_SYMBOL_COMPLETED) completion_events++;
+      else if (event_type == MARPA_EVENT_SYMBOL_PREDICTED) prediction_events++;
+      else if (event_type == MARPA_EVENT_EXHAUSTED) exhausted_event_triggered++;
+      else
+      {
+        printf ("spurious event type is %ld\n", (long) event_type);
+        spurious_events++;
+      }
+    }
+
+    is_int(0, spurious_events, "spurious events triggered: %ld", (long) spurious_events);
+    is_int(0, completion_events, "completion events triggered: %ld", (long) completion_events);
+    is_int(0, prediction_events, "completion events triggered: %ld", (long) prediction_events);
+    ok (exhausted_event_triggered, "exhausted event triggered");
+
+  }
+
   return 0;
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -686,14 +686,11 @@ main (int argc, char *argv[])
     if (!rc)
       fail("marpa_r_start_input", g);
 
-    Marpa_Symbol_ID S_expected = S_A1;
+    Marpa_Symbol_ID S_expected = S_A2;
     int value = 1;
     marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
 
-    diag ("at earleme 0");
-    marpa_m_test("marpa_r_is_exhausted", r, 1);
-
-    {
+    { /* event loop -- just count events so far -- there must be no event except exhausted */
       Marpa_Event event;
       int exhausted_event_triggered = 0;
       int spurious_events = 0;
@@ -725,7 +722,12 @@ main (int argc, char *argv[])
       is_int(0, prediction_events, "completion events triggered: %ld", (long) prediction_events);
       ok (exhausted_event_triggered, "exhausted event triggered");
 
-    }
-  }
+    } /* event loop */
+
+    diag ("at earleme 0");
+    marpa_m_test("marpa_r_is_exhausted", r, 1);
+
+  } /* recce method tests */
+
   return 0;
 }

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -678,9 +678,13 @@ main (int argc, char *argv[])
   marpa_g_trivial_precompute(g, S_top);
   ok(1, "precomputation succeeded");
 
-  /* event methods after precomputation
-     if the grammar g is precomputed; or on other failure, -2.
-   */
+  /* event methods after precomputation */
+  for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
+  {
+    marpa_m_test(marpa_g_event_setters[ix], g, whatever, whatever, -2, MARPA_ERR_PRECOMPUTED);
+  }
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
 
   /* Recognizer Methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -631,10 +631,50 @@ main (int argc, char *argv[])
   reactivate = 0;
   marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
 
-// malformed/invalid symbols
+  /* prediction */
+  S_predicted = S_A1;
 
-*/
+  value = 0;
+  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
 
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+
+  reactivate = 1;
+  marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
+
+  reactivate = 0;
+  marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
+
+  /* completion on predicted symbol */
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_predicted, value, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_predicted, value);
+
+  /* predicton on completed symbol */
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_completed, value, value);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_completed, value);
+
+  /* invalid/no such symbol IDs */
+  const char *marpa_g_event_setters[] = {
+    "marpa_g_symbol_is_completion_event_set", "marpa_g_completion_symbol_activate",
+    "marpa_g_symbol_is_prediction_event_set","marpa_g_prediction_symbol_activate",
+  };
+  for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
+  {
+    marpa_m_test(marpa_g_event_setters[ix], g, S_invalid, whatever, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+    marpa_m_test(marpa_g_event_setters[ix], g, S_no_such, whatever, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+  }
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+  /* precomputation */
   marpa_g_trivial_precompute(g, S_top);
   ok(1, "precomputation succeeded");
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -436,20 +436,6 @@ main (int argc, char *argv[])
 
     diag ("The below recce tests are at earleme 0");
 
-    Marpa_Symbol_ID S_expected = S_A2;
-    int value = 1;
-    marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
-
-    /* recognizer reading methods */
-    Marpa_Symbol_ID S_token = S_A2;
-    marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0,
-      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input is checked before invalid symbol");
-    marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0,
-      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input is checked before no such symbol");
-    marpa_m_test("marpa_r_alternative", r, S_token, 0, 0,
-      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input");
-    marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
-
     { /* event loop -- just count events so far -- there must be no event except exhausted */
       Marpa_Event event;
       int exhausted_event_triggered = 0;
@@ -484,7 +470,21 @@ main (int argc, char *argv[])
 
     } /* event loop */
 
-    marpa_m_test("marpa_r_is_exhausted", r, 1);
+    Marpa_Symbol_ID S_expected = S_A2;
+    int value = 1;
+    marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
+
+    /* recognizer reading methods */
+    Marpa_Symbol_ID S_token = S_A2;
+    marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0,
+      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input is checked before invalid symbol");
+    marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0,
+      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input is checked before no such symbol");
+    marpa_m_test("marpa_r_alternative", r, S_token, 0, 0,
+      MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "not accepting input");
+    marpa_m_test("marpa_r_earleme_complete", r, -2, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+
+    marpa_m_test("marpa_r_is_exhausted", r, 1, "at earleme 0");
 
   } /* recce method tests */
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -434,10 +434,6 @@ main (int argc, char *argv[])
 
   int whatever;
 
-  int reactivate;
-  int value;
-  Marpa_Symbol_ID S_predicted, S_completed;
-
   plan_lazy();
 
   marpa_c_init (&marpa_configuration);
@@ -613,78 +609,81 @@ main (int argc, char *argv[])
   /* Events */
   /* test that attempts to create events, other than nulled events,
      results in a reasonable error -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111838 */
-
-  /* completion */
-  S_completed = S_B1;
-
-  value = 0;
-  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
-  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
-
-  value = 1;
-  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
-  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
-
-  reactivate = 1;
-  marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
-
-  reactivate = 0;
-  marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
-
-  /* prediction */
-  S_predicted = S_A1;
-
-  value = 0;
-  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
-  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
-
-  value = 1;
-  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
-  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
-
-  reactivate = 1;
-  marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
-
-  reactivate = 0;
-  marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
-
-  /* completion on predicted symbol */
-  value = 1;
-  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_predicted, value, value);
-  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_predicted, value);
-
-  /* predicton on completed symbol */
-  value = 1;
-  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_completed, value, value);
-  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_completed, value);
-
-  /* invalid/no such symbol IDs */
-  const char *marpa_g_event_setters[] = {
-    "marpa_g_symbol_is_completion_event_set", "marpa_g_completion_symbol_activate",
-    "marpa_g_symbol_is_prediction_event_set","marpa_g_prediction_symbol_activate",
-  };
-  for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
   {
-    marpa_m_test(marpa_g_event_setters[ix], g, S_invalid, whatever, -2, MARPA_ERR_INVALID_SYMBOL_ID);
-    marpa_m_test(marpa_g_event_setters[ix], g, S_no_such, whatever, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+    int reactivate;
+    int value;
+    Marpa_Symbol_ID S_predicted, S_completed;
+
+    /* completion */
+    S_completed = S_B1;
+
+    value = 0;
+    marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
+    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
+
+    value = 1;
+    marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
+    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
+
+    reactivate = 0;
+    marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
+
+    reactivate = 1;
+    marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
+
+    /* prediction */
+    S_predicted = S_A1;
+
+    value = 0;
+    marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
+    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+
+    value = 1;
+    marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
+    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+
+    reactivate = 0;
+    marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
+
+    reactivate = 1;
+    marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
+
+    /* completion on predicted symbol */
+    value = 1;
+    marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_predicted, value, value);
+    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_predicted, value);
+
+    /* prediction on completed symbol */
+    value = 1;
+    marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_completed, value, value);
+    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_completed, value);
+
+    /* invalid/no such symbol IDs */
+    const char *marpa_g_event_setters[] = {
+      "marpa_g_symbol_is_completion_event_set", "marpa_g_completion_symbol_activate",
+      "marpa_g_symbol_is_prediction_event_set","marpa_g_prediction_symbol_activate",
+    };
+    for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
+    {
+      marpa_m_test(marpa_g_event_setters[ix], g, S_invalid, whatever, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+      marpa_m_test(marpa_g_event_setters[ix], g, S_no_such, whatever, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+    }
+    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+    /* precomputation */
+    marpa_g_trivial_precompute(g, S_top);
+    ok(1, "precomputation succeeded");
+
+    /* event methods after precomputation */
+    for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
+      marpa_m_test(marpa_g_event_setters[ix], g, whatever, whatever, -2, MARPA_ERR_PRECOMPUTED);
+    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
   }
-  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
-  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
-
-  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
-  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
-
-  /* precomputation */
-  marpa_g_trivial_precompute(g, S_top);
-  ok(1, "precomputation succeeded");
-
-  /* event methods after precomputation */
-  for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
-  {
-    marpa_m_test(marpa_g_event_setters[ix], g, whatever, whatever, -2, MARPA_ERR_PRECOMPUTED);
-  }
-  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
-  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
 
   /* Recognizer Methods */
   r = marpa_r_new (g);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -432,8 +432,11 @@ main (int argc, char *argv[])
   Marpa_Rank negative_rank, positive_rank;
   int flag;
 
+  int whatever;
+
   int reactivate;
   int value;
+  Marpa_Symbol_ID S_predicted, S_completed;
 
   plan_lazy();
 
@@ -610,25 +613,23 @@ main (int argc, char *argv[])
   /* Events */
   /* test that attempts to create events, other than nulled events,
      results in a reasonable error -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111838 */
-/*
 
-reactivate = 1;
-reactivate = 0;
-int marpa_g_completion_symbol_activate (g, S_top, reactivate )
-int marpa_g_prediction_symbol_activate (g, S_top, reactivate )
+  /* completion */
+  S_completed = S_B1;
 
-// If the active status of the completion event for sym_id cannot be set as
-// indicated by reactivate, the method fails. On failure, -2 is returned.
+  value = 0;
+  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
 
-value = 1;
-int marpa_g_symbol_is_completion_event (g, S_top)
-int marpa_g_symbol_is_completion_event_set ( g, S_top, value)
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
 
-int marpa_g_symbol_is_prediction_event (g, S_top)
-int marpa_g_symbol_is_prediction_event_set (g, S_top, value)
+  reactivate = 1;
+  marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
 
-// On success, 1 if symbol sym_id is an event symbol after the call, 0 otherwise.
-// If sym_id is well-formed, but there is no such symbol, -1.
+  reactivate = 0;
+  marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
 
 // malformed/invalid symbols
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -587,13 +587,7 @@ main (int argc, char *argv[])
 
   /* Ranks methods on precomputed grammar */
   marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, negative_rank, -2, MARPA_ERR_PRECOMPUTED);
-  if (marpa_g_rule_rank(g, R_top_1) == negative_rank)
-    if (marpa_g_error(g, NULL) == MARPA_ERR_NONE)
-      ok(1, "marpa_g_rule_rank() returns negative_rank and marpa_g_error() returns MARPA_ERR_NONE");
-    else
-      ok(0, "marpa_g_rule_rank() returns negative_rank and marpa_g_error() returns MARPA_ERR_NONE");
-  else
-    ok(0, "marpa_g_rule_rank() returns negative_rank");
+  marpa_m_test("marpa_g_rule_rank_set", g, R_top_1, negative_rank);
 
   marpa_m_test("marpa_g_rule_rank_set", g, R_top_2, positive_rank, -2, MARPA_ERR_PRECOMPUTED);
   marpa_m_test("marpa_g_rule_rank_set", g, R_top_2, positive_rank);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -168,8 +168,6 @@ main (int argc, char *argv[])
   Marpa_Grammar g;
   Marpa_Recognizer r;
 
-  Marpa_Symbol_ID S_invalid, S_no_such;
-  Marpa_Rule_ID R_invalid, R_no_such;
   Marpa_Rank negative_rank, positive_rank;
   int flag;
 
@@ -183,8 +181,6 @@ main (int argc, char *argv[])
   marpa_m_grammar_set(g); /* for marpa_g_error() in marpa_m_test() */
 
   /* Grammar Methods per sections of api.texi: Symbols, Rules, Sequnces, Ranks, Events */
-  S_invalid = R_invalid = -1;
-  S_no_such = R_no_such = 42;
 
   marpa_m_test("marpa_g_symbol_is_start", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
   marpa_m_test("marpa_g_symbol_is_start", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -486,6 +486,20 @@ main (int argc, char *argv[])
 
     marpa_m_test("marpa_r_is_exhausted", r, 1, "at earleme 0");
 
+    /* Location accessors */
+    {
+      /* the below 2 always succeed */
+      unsigned int current_earleme = 0;
+      marpa_m_test("marpa_r_current_earleme", r, current_earleme);
+
+      unsigned int furthest_earleme = current_earleme;
+      marpa_m_test("marpa_r_furthest_earleme", r, furthest_earleme);
+
+      marpa_m_test("marpa_r_latest_earley_set", r, furthest_earleme);
+
+      marpa_m_test("marpa_r_earleme", r, current_earleme, -2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION);
+
+    }
   } /* recce method tests */
 
   return 0;

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -221,6 +221,14 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_g_rule_null_high_set", &marpa_g_rule_null_high_set, "%r, %i" },
   { "marpa_g_rule_null_high", &marpa_g_rule_null_high, "%r" },
 
+  { "marpa_g_symbol_is_completion_event_set", &marpa_g_symbol_is_completion_event_set, "%s, %i" },
+  { "marpa_g_symbol_is_completion_event", &marpa_g_symbol_is_completion_event, "%s" },
+  { "marpa_g_completion_symbol_activate", &marpa_g_completion_symbol_activate, "%s, %i" },
+
+  { "marpa_g_symbol_is_prediction_event_set", &marpa_g_symbol_is_prediction_event_set, "%s, %i" },
+  { "marpa_g_symbol_is_prediction_event", &marpa_g_symbol_is_prediction_event, "%s" },
+  { "marpa_g_prediction_symbol_activate", &marpa_g_prediction_symbol_activate, "%s, %i" },
+
   { "marpa_r_is_exhausted", &marpa_r_is_exhausted, "" },
 };
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include "marpa.h"
 
-#include "tap/basic.h"
+#include "marpa_test.h"
 
 static int
 warn (const char *s, Marpa_Grammar g)
@@ -155,260 +155,6 @@ marpa_g_trivial_precompute(Marpa_Grammar g, Marpa_Symbol_ID S_start)
     fail("marpa_g_precompute", g);
 
   return rc;
-}
-
-/* Marpa method test interface */
-
-typedef int (*marpa_m_pointer)();
-
-/*
-    %s -- Marpa_Symbol_ID
-    %r -- Marpa_Rule_ID
-    %n -- Marpa_Rank
-    ...
-*/
-typedef char *marpa_m_argspec;
-typedef char *marpa_m_name;
-
-struct marpa_method_spec {
-  marpa_m_name n;
-  marpa_m_pointer p;
-  marpa_m_argspec as;
-};
-
-typedef struct marpa_method_spec Marpa_Method_Spec;
-
-const Marpa_Method_Spec methspec[] = {
-
-  { "marpa_g_start_symbol_set", &marpa_g_start_symbol_set, "%s" },
-  { "marpa_g_symbol_is_start", &marpa_g_symbol_is_start, "%s" },
-  { "marpa_g_start_symbol", &marpa_g_start_symbol, "" },
-
-  { "marpa_g_symbol_is_terminal_set", &marpa_g_symbol_is_terminal_set, "%s, %i" },
-  { "marpa_g_symbol_is_terminal",  &marpa_g_symbol_is_terminal, "%s" },
-
-  { "marpa_g_highest_symbol_id", &marpa_g_highest_symbol_id, ""},
-
-  { "marpa_g_symbol_is_accessible", &marpa_g_symbol_is_accessible, "%s" },
-  { "marpa_g_symbol_is_nullable", &marpa_g_symbol_is_nullable, "%s" },
-  { "marpa_g_symbol_is_nulling", &marpa_g_symbol_is_nulling, "%s" },
-  { "marpa_g_symbol_is_productive", &marpa_g_symbol_is_productive, "%s" },
-
-  { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
-  { "marpa_g_rule_is_nulling", &marpa_g_rule_is_nulling, "%r" },
-  { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
-
-  { "marpa_g_precompute", &marpa_g_precompute, "" },
-
-  { "marpa_g_highest_rule_id", &marpa_g_highest_rule_id, "" },
-  { "marpa_g_rule_is_accessible", &marpa_g_rule_is_accessible, "%r" },
-  { "marpa_g_rule_is_nullable", &marpa_g_rule_is_nullable, "%r" },
-  { "marpa_g_rule_is_nulling", &marpa_g_rule_is_nulling, "%r" },
-  { "marpa_g_rule_is_loop", &marpa_g_rule_is_loop, "%r" },
-  { "marpa_g_rule_is_productive", &marpa_g_rule_is_productive, "%r" },
-  { "marpa_g_rule_length", &marpa_g_rule_length, "%r" },
-  { "marpa_g_rule_lhs", &marpa_g_rule_lhs, "%r" },
-  { "marpa_g_rule_rhs", &marpa_g_rule_rhs, "%r, %i" },
-
-  { "marpa_g_sequence_new", &marpa_g_sequence_new, "%s, %s, %s, %i, %i" },
-  { "marpa_g_rule_is_proper_separation", &marpa_g_rule_is_proper_separation, "%r" },
-  { "marpa_g_sequence_min", &marpa_g_sequence_min, "%r" },
-  { "marpa_g_sequence_separator", &marpa_g_sequence_separator, "%r" },
-  { "marpa_g_symbol_is_counted", &marpa_g_symbol_is_counted, "%s" },
-
-  { "marpa_g_rule_rank_set", &marpa_g_rule_rank_set, "%r, %i" },
-  { "marpa_g_rule_rank", &marpa_g_rule_rank, "%r" },
-  { "marpa_g_rule_null_high_set", &marpa_g_rule_null_high_set, "%r, %i" },
-  { "marpa_g_rule_null_high", &marpa_g_rule_null_high, "%r" },
-
-  { "marpa_g_symbol_is_completion_event_set", &marpa_g_symbol_is_completion_event_set, "%s, %i" },
-  { "marpa_g_symbol_is_completion_event", &marpa_g_symbol_is_completion_event, "%s" },
-  { "marpa_g_completion_symbol_activate", &marpa_g_completion_symbol_activate, "%s, %i" },
-
-  { "marpa_g_symbol_is_prediction_event_set", &marpa_g_symbol_is_prediction_event_set, "%s, %i" },
-  { "marpa_g_symbol_is_prediction_event", &marpa_g_symbol_is_prediction_event, "%s" },
-  { "marpa_g_prediction_symbol_activate", &marpa_g_prediction_symbol_activate, "%s, %i" },
-
-  { "marpa_r_expected_symbol_event_set", &marpa_r_expected_symbol_event_set, "%s, %i" },
-  { "marpa_r_is_exhausted", &marpa_r_is_exhausted, "" },
-
-  { "marpa_r_alternative", &marpa_r_alternative, "%s, %i, %i" },
-  { "marpa_r_earleme_complete", &marpa_r_earleme_complete, "" },
-
-};
-
-static Marpa_Method_Spec
-marpa_m_method_spec(const char *name)
-{
-  int i;
-  for (i = 0; i < sizeof(methspec) / sizeof(Marpa_Method_Spec); i++)
-    if ( strcmp(name, methspec[i].n ) == 0 )
-      return methspec[i];
-  printf("No spec yet for Marpa method %s().\n", name);
-  exit(1);
-}
-
-typedef char *marpa_m_errmsg;
-struct marpa_m_error {
-  Marpa_Error_Code c;
-  marpa_m_errmsg m;
-};
-
-typedef struct marpa_m_error Marpa_Method_Error;
-
-const Marpa_Method_Error errspec[] = {
-  { MARPA_ERR_NO_START_SYMBOL, "no start symbol" },
-  { MARPA_ERR_INVALID_SYMBOL_ID, "invalid symbol id" },
-  { MARPA_ERR_NO_SUCH_SYMBOL_ID, "no such symbol id" },
-  { MARPA_ERR_NOT_PRECOMPUTED, "grammar not precomputed" },
-  { MARPA_ERR_TERMINAL_IS_LOCKED, "terminal locked" },
-  { MARPA_ERR_NULLING_TERMINAL, "nulling terminal" },
-  { MARPA_ERR_PRECOMPUTED, "grammar precomputed" },
-  { MARPA_ERR_SEQUENCE_LHS_NOT_UNIQUE, "sequence lhs not unique" },
-  { MARPA_ERR_NOT_A_SEQUENCE, "not a sequence rule" },
-  { MARPA_ERR_INVALID_RULE_ID, "invalid rule id" },
-  { MARPA_ERR_NO_SUCH_RULE_ID, "no such rule id" },
-  { MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT, "recce not accepting input" },
-};
-
-static char *marpa_m_error_message (Marpa_Error_Code error_code)
-{
-  int i;
-  for (i = 0; i < sizeof(errspec) / sizeof(Marpa_Method_Error); i++)
-    if ( error_code == errspec[i].c )
-      return errspec[i].m;
-  printf("No message yet for Marpa error code %d.\n", error_code);
-  exit(1);
-}
-
-/* we need a grammar to call marpa_g_error() */
-static Marpa_Grammar marpa_m_g = NULL;
-
-static int
-marpa_m_grammar_set(Marpa_Grammar g) { marpa_m_g = g; }
-
-static Marpa_Grammar
-marpa_m_grammar() { return marpa_m_g; }
-
-static int
-marpa_m_test(const char* name, ...)
-{
-  Marpa_Method_Spec ms;
-
-  Marpa_Grammar g;
-  Marpa_Recognizer r;
-
-  Marpa_Symbol_ID S_id, S_id1, S_id2;
-  Marpa_Rule_ID R_id;
-  int intarg, intarg1;
-
-  int rv_wanted, rv_seen;
-  int err_wanted, err_seen;
-
-  char tok_buf[32];  /* strtok() */
-  char desc_buf[80]; /* test description  */
-  char *curr_arg;
-  int curr_arg_ix;
-
-  ms = marpa_m_method_spec(name);
-
-  va_list args;
-  va_start(args, name);
-
-  g = marpa_m_grammar();
-
-  void *marpa_m_object = va_arg(args, void*);
-
-#define ARG_UNDEF 42424242
-  R_id = S_id = S_id1 = S_id2 = intarg = intarg1 = ARG_UNDEF;
-  strcpy( tok_buf, ms.as );
-  curr_arg = strtok(tok_buf, " ,-");
-  while (curr_arg != NULL)
-  {
-    if (strncmp(curr_arg, "%s", 2) == 0){
-      if (S_id == ARG_UNDEF) S_id = va_arg(args, Marpa_Symbol_ID);
-      else if (S_id1 == ARG_UNDEF) S_id1 = va_arg(args, Marpa_Symbol_ID);
-      else if (S_id2 == ARG_UNDEF) S_id2 = va_arg(args, Marpa_Symbol_ID);
-    }
-    else if (strncmp(curr_arg, "%r", 2) == 0)
-    {
-      R_id   = va_arg(args, Marpa_Rule_ID);
-    }
-    else if (strncmp(curr_arg, "%i", 2) == 0)
-    {
-      if (intarg == ARG_UNDEF) intarg = va_arg(args, int);
-      else if (intarg1 == ARG_UNDEF) intarg1 = va_arg(args, int);
-    }
-
-    curr_arg = strtok(NULL, " ,-");
-    curr_arg_ix++;
-  }
-
-  /* call marpa method based on argspec */
-  if (ms.as == "") rv_seen = ms.p(marpa_m_object);
-  else if (strcmp(ms.as, "%s") == 0) rv_seen = ms.p(marpa_m_object, S_id);
-  else if (strcmp(ms.as, "%r") == 0) rv_seen = ms.p(marpa_m_object, R_id);
-  else if (strcmp(ms.as, "%s, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, intarg);
-  else if (strcmp(ms.as, "%s, %i, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, intarg, intarg1);
-  else if (strcmp(ms.as, "%r, %i") == 0) rv_seen = ms.p(marpa_m_object, R_id, intarg);
-  else if (strcmp(ms.as, "%s, %s, %s, %i, %i") == 0) rv_seen = ms.p(marpa_m_object, S_id, S_id1, S_id2, intarg, intarg1);
-  else
-  {
-    printf("No method yet for argument spec %s.\n", ms.as);
-    exit(1);
-  }
-
-  rv_wanted = va_arg(args, int);
-
-  /* success wanted */
-  if ( rv_wanted >= 0 )
-  {
-    /* failure seen */
-    if ( rv_seen < 0 )
-    {
-      sprintf(msgbuf, "%s() unexpectedly returned %d.", name, rv_seen);
-      ok(0, msgbuf);
-    }
-    /* success seen */
-    else {
-      sprintf(desc_buf, "%s()", name);
-      is_int( rv_wanted, rv_seen, desc_buf );
-    }
-  }
-  /* marpa_g_rule_rank() and marpa_g_rule_rank_set() may return negative values,
-     but they are actually ranks if marpa_g_error() returns MARPA_ERR_NONE.
-     So, we don't count them as failures. */
-  else if ( strncmp( name, "marpa_g_rule_rank", 17 ) == 0
-              && marpa_g_error(g, NULL) == MARPA_ERR_NONE )
-    {
-      sprintf(desc_buf, "%s() succeeded", name);
-      is_int( rv_wanted, rv_seen, desc_buf );
-    }
-  /* failure wanted */
-  else
-  {
-    /* return value */
-    err_wanted = va_arg(args, int);
-    sprintf(desc_buf, "%s() failed, returned %d", name, rv_seen);
-    is_int( rv_wanted, rv_seen, desc_buf );
-
-    /* error code */
-    err_seen = marpa_g_error(g, NULL);
-
-    if (err_seen == MARPA_ERR_NONE && rv_seen < 0)
-    {
-      sprintf(msgbuf, "%s(): marpa_g_error() returned MARPA_ERR_NONE, but return value was %d.", name, rv_seen);
-      ok(0, msgbuf);
-    }
-    /* test error code */
-    else
-    {
-      sprintf(desc_buf, "%s() error is: %s", name, marpa_m_error_message(err_seen));
-      is_int( err_wanted, err_seen, desc_buf );
-    }
-  }
-
-  va_end(args);
 }
 
 int
@@ -688,6 +434,9 @@ main (int argc, char *argv[])
     if (!r)
       fail("marpa_r_new", g);
 
+    Marpa_Symbol_ID S_token = S_A2;
+    marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
+
     rc = marpa_r_start_input (r);
     if (!rc)
       fail("marpa_r_start_input", g);
@@ -699,7 +448,6 @@ main (int argc, char *argv[])
     marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
 
     /* recognizer reading methods */
-    Marpa_Symbol_ID S_token = S_A2;
     marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0, MARPA_ERR_INVALID_SYMBOL_ID);
     marpa_m_test("marpa_r_alternative", r, S_no_such, 0, 0, MARPA_ERR_NO_SUCH_SYMBOL_ID);
     marpa_m_test("marpa_r_alternative", r, S_token, 0, 0, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);

--- a/work/dev/marpa.w
+++ b/work/dev/marpa.w
@@ -7806,11 +7806,16 @@ Marpa_Earleme marpa_r_alternative(
         MARPA_ERROR (MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
         return MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT;
       }
-    if (_MARPA_UNLIKELY (!xsy_id_is_valid (g, tkn_xsy_id)))
+    if (_MARPA_UNLIKELY (XSYID_is_Malformed(tkn_xsy_id)))
       {
         MARPA_ERROR (MARPA_ERR_INVALID_SYMBOL_ID);
         return MARPA_ERR_INVALID_SYMBOL_ID;
-    }
+      }
+    if (_MARPA_UNLIKELY (!XSYID_of_G_Exists(tkn_xsy_id)))
+      {
+        MARPA_ERROR (MARPA_ERR_NO_SUCH_SYMBOL_ID);
+        return MARPA_ERR_NO_SUCH_SYMBOL_ID;
+      }
     @<|marpa_alternative| initial check for failure conditions@>@;
     @<Set |current_earley_set|, failing if token is unexpected@>@;
     @<Set |target_earleme| or fail@>@;


### PR DESCRIPTION
This one adds tests for methods under 11.8 Events (all pass), 12.4 Life cycle mutators, and (some of) 12.5 Location Accessors.

`marpa_r_alternative()` returned `MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT` with invalid/non-existing token symbol IDs, so I moved `marpa_m_test` to a separate file and added another test script `nits.c` to test on a simple, but non-nulling, grammar. `marpa_r_alternative()` still returned `MARPA_ERR_INVALID_SYMBOL_ID` for both invalid and non-existing token symbols, so I attempted a fix in cc574e4 and modified tests accordingly.

This call sequence
```c
marpa_r_earleme(r, 0);
marpa_r_earley_set_value (r, 0);
```
in commit 4426a73 dumped core under cygwin.

Without preceding `marpa_r_earleme(r, 0);` call, `marpa_r_earley_set_value (r, 0);` call works ok.

 I traced it to
`if (!MARPA_DSTACK_IS_INITIALIZED(r->t_earley_set_stack)) {` line in `r_update_earley_sets()`.
