### PR TITLE
Method census trivial grammar 12.6 Other parse status methods

### DIFF
--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -104,11 +104,14 @@ const Marpa_Method_Spec methspec[] = {
 
   { "marpa_r_prediction_symbol_activate", &marpa_r_prediction_symbol_activate, "%s, %i" },
   { "marpa_r_completion_symbol_activate", &marpa_r_completion_symbol_activate, "%s, %i" },
+  { "marpa_r_nulled_symbol_activate", &marpa_r_nulled_symbol_activate, "%s, %i" },
 
   { "marpa_r_earley_item_warning_threshold_set", &marpa_r_earley_item_warning_threshold_set, "%i" },
   { "marpa_r_earley_item_warning_threshold", &marpa_r_earley_item_warning_threshold, "" },
 
   { "marpa_r_expected_symbol_event_set", &marpa_r_expected_symbol_event_set, "%s, %i" },
+  { "marpa_r_terminals_expected", &marpa_r_terminals_expected, "%s, %ip" },
+  { "marpa_r_terminal_is_expected", &marpa_r_terminal_is_expected, "%s" },
 };
 
 static Marpa_Method_Spec
@@ -264,6 +267,8 @@ marpa_m_test_func(const char* name, ...)
     rv_seen = ms.p(marpa_m_object, R_id);
   else if (strcmp(ms.as, "%s, %i") == 0)
     rv_seen = ms.p(marpa_m_object, S_id, arg_int);
+  else if (strcmp(ms.as, "%s, %ip") == 0)
+    rv_seen = ms.p(marpa_m_object, S_id, arg_p_int);
   else if (strcmp(ms.as, "%s, %i, %i") == 0)
     rv_seen = ms.p(marpa_m_object, S_id, arg_int, arg_int1);
   else if (strcmp(ms.as, "%r, %i") == 0)
@@ -326,6 +331,7 @@ marpa_m_test_func(const char* name, ...)
         "%s() error is: %s", name, marpa_m_error_message(err_seen) );
     }
   }
+  /* todo: add handling */
 
   va_end(args);
 }

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -104,6 +104,9 @@ const Marpa_Method_Spec methspec[] = {
 
   { "marpa_r_prediction_symbol_activate", &marpa_r_prediction_symbol_activate, "%s, %i" },
   { "marpa_r_completion_symbol_activate", &marpa_r_completion_symbol_activate, "%s, %i" },
+
+  { "marpa_r_earley_item_warning_threshold_set", &marpa_r_earley_item_warning_threshold_set, "%i" },
+  { "marpa_r_earley_item_warning_threshold", &marpa_r_earley_item_warning_threshold, "" },
 };
 
 static Marpa_Method_Spec

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -142,6 +142,7 @@ const Marpa_Method_Error errspec[] = {
   { MARPA_ERR_PARSE_EXHAUSTED, "parse exhausted" },
   { MARPA_ERR_NO_EARLEY_SET_AT_LOCATION, "no earley set at location" },
   { MARPA_ERR_INVALID_LOCATION, "location not valid" },
+  { MARPA_ERR_SYMBOL_IS_NULLING, "symbol is nulling" },
 };
 
 char *marpa_m_error_message (Marpa_Error_Code error_code)

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -107,6 +107,8 @@ const Marpa_Method_Spec methspec[] = {
 
   { "marpa_r_earley_item_warning_threshold_set", &marpa_r_earley_item_warning_threshold_set, "%i" },
   { "marpa_r_earley_item_warning_threshold", &marpa_r_earley_item_warning_threshold, "" },
+
+  { "marpa_r_expected_symbol_event_set", &marpa_r_expected_symbol_event_set, "%s, %i" },
 };
 
 static Marpa_Method_Spec

--- a/test/simple/marpa_test.c
+++ b/test/simple/marpa_test.c
@@ -100,8 +100,10 @@ const Marpa_Method_Spec methspec[] = {
   { "marpa_r_earley_set_value", &marpa_r_earley_set_value, "%i" },
   { "marpa_r_earley_set_values", &marpa_r_earley_set_values, "%i, %ip, %vpp" },
   { "marpa_r_latest_earley_set_value_set", &marpa_r_latest_earley_set_value_set, "%i" },
-  { "marpa_r_latest_earley_set_values_set", &marpa_r_latest_earley_set_values_set, "%i, %vp" }
+  { "marpa_r_latest_earley_set_values_set", &marpa_r_latest_earley_set_values_set, "%i, %vp" },
 
+  { "marpa_r_prediction_symbol_activate", &marpa_r_prediction_symbol_activate, "%s, %i" },
+  { "marpa_r_completion_symbol_activate", &marpa_r_completion_symbol_activate, "%s, %i" },
 };
 
 static Marpa_Method_Spec

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -584,6 +584,9 @@ main (int argc, char *argv[])
       marpa_m_test("marpa_r_completion_symbol_activate", r, S_no_such, reactivate,
         -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
 
+      int threshold = 1;
+      marpa_m_test("marpa_r_earley_item_warning_threshold_set", r, threshold, threshold);
+      marpa_m_test("marpa_r_earley_item_warning_threshold", r, threshold);
 
     }
 

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -570,8 +570,23 @@ main (int argc, char *argv[])
 
     /* Other parse status methods */
     {
+      int boolean = 0;
+      marpa_m_test("marpa_r_prediction_symbol_activate", r, S_predicted, boolean, boolean );
+      marpa_m_test("marpa_r_prediction_symbol_activate", r, S_invalid, boolean,
+        -2, MARPA_ERR_INVALID_SYMBOL_ID);
+      marpa_m_test("marpa_r_prediction_symbol_activate", r, S_no_such, boolean,
+        -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+      reactivate = 1;
+      marpa_m_test("marpa_r_completion_symbol_activate", r, S_completed, reactivate, reactivate );
+      marpa_m_test("marpa_r_completion_symbol_activate", r, S_invalid, reactivate,
+        -2, MARPA_ERR_INVALID_SYMBOL_ID);
+      marpa_m_test("marpa_r_completion_symbol_activate", r, S_no_such, reactivate,
+        -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
 
     }
+
   } /* recce method tests */
 
   return 0;

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -588,6 +588,10 @@ main (int argc, char *argv[])
       marpa_m_test("marpa_r_earley_item_warning_threshold_set", r, threshold, threshold);
       marpa_m_test("marpa_r_earley_item_warning_threshold", r, threshold);
 
+      Marpa_Symbol_ID S_expected = S_B1;
+      value = 1;
+      marpa_m_test("marpa_r_expected_symbol_event_set", r, S_B1, value, value);
+
     }
 
   } /* recce method tests */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -598,7 +598,8 @@ main (int argc, char *argv[])
         -2, MARPA_ERR_SYMBOL_IS_NULLING);
 
       Marpa_Symbol_ID buffer[42];
-      marpa_m_test("marpa_r_terminals_expected", r, buffer, -2, 0);
+      marpa_m_test("marpa_r_terminals_expected", r, buffer, 0);
+
       marpa_m_test("marpa_r_terminal_is_expected", r, S_C1, 0);
       marpa_m_test("marpa_r_terminal_is_expected", r, S_invalid,
         -2, MARPA_ERR_INVALID_SYMBOL_ID);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -584,6 +584,14 @@ main (int argc, char *argv[])
       marpa_m_test("marpa_r_completion_symbol_activate", r, S_no_such, reactivate,
         -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
 
+      boolean = 1;
+      Marpa_Symbol_ID S_nulled = S_C1;
+      marpa_m_test("marpa_r_nulled_symbol_activate", r, S_nulled, boolean, boolean );
+      marpa_m_test("marpa_r_nulled_symbol_activate", r, S_invalid, boolean,
+        -2, MARPA_ERR_INVALID_SYMBOL_ID);
+      marpa_m_test("marpa_r_nulled_symbol_activate", r, S_no_such, boolean,
+        -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
       int threshold = 1;
       marpa_m_test("marpa_r_earley_item_warning_threshold_set", r, threshold, threshold);
       marpa_m_test("marpa_r_earley_item_warning_threshold", r, threshold);
@@ -592,6 +600,13 @@ main (int argc, char *argv[])
       value = 1;
       marpa_m_test("marpa_r_expected_symbol_event_set", r, S_B1, value, value);
 
+      Marpa_Symbol_ID buffer[42];
+      marpa_m_test("marpa_r_terminals_expected", r, buffer, -2, 0);
+      marpa_m_test("marpa_r_terminal_is_expected", r, S_C1, 0);
+      marpa_m_test("marpa_r_terminal_is_expected", r, S_invalid,
+        -2, MARPA_ERR_INVALID_SYMBOL_ID);
+      marpa_m_test("marpa_r_terminal_is_expected", r, S_no_such,
+        -2, MARPA_ERR_NO_SUCH_SYMBOL_ID);
     }
 
   } /* recce method tests */

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -468,10 +468,6 @@ main (int argc, char *argv[])
 
     } /* event loop */
 
-    Marpa_Symbol_ID S_expected = S_A2;
-    value = 1;
-    marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
-
     /* recognizer reading methods */
     Marpa_Symbol_ID S_token = S_A2;
     marpa_m_test("marpa_r_alternative", r, S_invalid, 0, 0,
@@ -596,9 +592,10 @@ main (int argc, char *argv[])
       marpa_m_test("marpa_r_earley_item_warning_threshold_set", r, threshold, threshold);
       marpa_m_test("marpa_r_earley_item_warning_threshold", r, threshold);
 
-      Marpa_Symbol_ID S_expected = S_B1;
+      Marpa_Symbol_ID S_expected = S_C1;
       value = 1;
-      marpa_m_test("marpa_r_expected_symbol_event_set", r, S_B1, value, value);
+      marpa_m_test("marpa_r_expected_symbol_event_set", r, S_B1, value,
+        -2, MARPA_ERR_SYMBOL_IS_NULLING);
 
       Marpa_Symbol_ID buffer[42];
       marpa_m_test("marpa_r_terminals_expected", r, buffer, -2, 0);

--- a/test/simple/trivial1.c
+++ b/test/simple/trivial1.c
@@ -348,81 +348,79 @@ main (int argc, char *argv[])
   /* Events */
   /* test that attempts to create events, other than nulled events,
      results in a reasonable error -- http://irclog.perlgeek.de/marpa/2015-02-13#i_10111838 */
+  int reactivate;
+  int value;
+  Marpa_Symbol_ID S_predicted, S_completed;
+
+  /* completion */
+  S_completed = S_B1;
+
+  value = 0;
+  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
+
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
+
+  reactivate = 0;
+  marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
+
+  reactivate = 1;
+  marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
+
+  /* prediction */
+  S_predicted = S_A1;
+
+  value = 0;
+  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+
+  reactivate = 0;
+  marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
+
+  reactivate = 1;
+  marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
+
+  /* completion on predicted symbol */
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_predicted, value, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_predicted, value);
+
+  /* prediction on completed symbol */
+  value = 1;
+  marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_completed, value, value);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_completed, value);
+
+  /* invalid/no such symbol IDs */
+  const char *marpa_g_event_setters[] = {
+    "marpa_g_symbol_is_completion_event_set", "marpa_g_completion_symbol_activate",
+    "marpa_g_symbol_is_prediction_event_set","marpa_g_prediction_symbol_activate",
+  };
+  for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
   {
-    int reactivate;
-    int value;
-    Marpa_Symbol_ID S_predicted, S_completed;
-
-    /* completion */
-    S_completed = S_B1;
-
-    value = 0;
-    marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
-    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
-
-    value = 1;
-    marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_completed, value, value);
-    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
-
-    reactivate = 0;
-    marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
-
-    reactivate = 1;
-    marpa_m_test("marpa_g_completion_symbol_activate", g, S_completed, reactivate, reactivate);
-
-    /* prediction */
-    S_predicted = S_A1;
-
-    value = 0;
-    marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
-    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
-
-    value = 1;
-    marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_predicted, value, value);
-    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
-
-    reactivate = 0;
-    marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
-
-    reactivate = 1;
-    marpa_m_test("marpa_g_prediction_symbol_activate", g, S_predicted, reactivate, reactivate);
-
-    /* completion on predicted symbol */
-    value = 1;
-    marpa_m_test("marpa_g_symbol_is_completion_event_set", g, S_predicted, value, value);
-    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_predicted, value);
-
-    /* prediction on completed symbol */
-    value = 1;
-    marpa_m_test("marpa_g_symbol_is_prediction_event_set", g, S_completed, value, value);
-    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_completed, value);
-
-    /* invalid/no such symbol IDs */
-    const char *marpa_g_event_setters[] = {
-      "marpa_g_symbol_is_completion_event_set", "marpa_g_completion_symbol_activate",
-      "marpa_g_symbol_is_prediction_event_set","marpa_g_prediction_symbol_activate",
-    };
-    for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
-    {
-      marpa_m_test(marpa_g_event_setters[ix], g, S_invalid, whatever, -2, MARPA_ERR_INVALID_SYMBOL_ID);
-      marpa_m_test(marpa_g_event_setters[ix], g, S_no_such, whatever, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
-    }
-    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
-    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
-
-    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
-    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
-
-    /* precomputation */
-    marpa_g_trivial_precompute(g, S_top);
-    ok(1, "precomputation succeeded");
-
-    /* event methods after precomputation */
-    for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
-      marpa_m_test(marpa_g_event_setters[ix], g, whatever, whatever, -2, MARPA_ERR_PRECOMPUTED);
-    marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
-    marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
+    marpa_m_test(marpa_g_event_setters[ix], g, S_invalid, whatever, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+    marpa_m_test(marpa_g_event_setters[ix], g, S_no_such, whatever, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
   }
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_invalid, -2, MARPA_ERR_INVALID_SYMBOL_ID);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_no_such, -1, MARPA_ERR_NO_SUCH_SYMBOL_ID);
+
+  /* precomputation */
+  marpa_g_trivial_precompute(g, S_top);
+  ok(1, "precomputation succeeded");
+
+  /* event methods after precomputation */
+  for (ix = 0; ix < sizeof(marpa_g_event_setters) / sizeof(char *); ix++)
+    marpa_m_test(marpa_g_event_setters[ix], g, whatever, whatever, -2, MARPA_ERR_PRECOMPUTED);
+  marpa_m_test("marpa_g_symbol_is_prediction_event", g, S_predicted, value);
+  marpa_m_test("marpa_g_symbol_is_completion_event", g, S_completed, value);
 
   /* Recognizer Methods */
   {
@@ -471,7 +469,7 @@ main (int argc, char *argv[])
     } /* event loop */
 
     Marpa_Symbol_ID S_expected = S_A2;
-    int value = 1;
+    value = 1;
     marpa_m_test("marpa_r_expected_symbol_event_set", r, S_expected, value, value);
 
     /* recognizer reading methods */
@@ -498,108 +496,83 @@ main (int argc, char *argv[])
       marpa_m_test("marpa_r_latest_earley_set", r, furthest_earleme);
       marpa_m_test("marpa_r_earleme", r, current_earleme, current_earleme);
       marpa_m_test("marpa_r_earley_set_value", r, current_earleme, -1, MARPA_ERR_RECCE_NOT_ACCEPTING_INPUT);
-    }
 
-  } /* recce method tests */
+      /* marpa_r_earley_set_value_*() methods */
+      int taxicab = 1729;
+      char *value2 = NULL;
+      int earley_set;
 
-{
-  /* Rewritten to use marpa_m_test() as the author requested in commit 25f4589 */
-  int taxicab = 1729;
-  char *value2 = NULL;
-  int earley_set;
+      struct marpa_r_earley_set_value_test {
+        int earley_set;
 
-  struct marpa_r_earley_set_value_test {
-    int earley_set;
+        int rv_marpa_r_earleme;
+        int rv_marpa_r_latest_earley_set_value_set;
+        int rv_marpa_r_earley_set_value;
+        int rv_marpa_r_latest_earley_set_values_set;
 
-    int rv_marpa_r_earleme;
-    int rv_marpa_r_latest_earley_set_value_set;
-    int rv_marpa_r_earley_set_value;
-    int rv_marpa_r_latest_earley_set_values_set;
+        int   rv_marpa_r_earley_set_values;
+        int   int_p_value_rv_marpa_r_earley_set_values;
+        char* void_p_value_rv_marpa_r_earley_set_values;
 
-    int   rv_marpa_r_earley_set_values;
-    int   int_p_value_rv_marpa_r_earley_set_values;
-    char* void_p_value_rv_marpa_r_earley_set_values;
+        Marpa_Error_Code errcode;
+      };
+      typedef struct marpa_r_earley_set_value_test Marpa_R_Earley_Set_Value_Test;
 
-    Marpa_Error_Code errcode;
-  };
-  typedef struct marpa_r_earley_set_value_test Marpa_R_Earley_Set_Value_Test;
+      const Marpa_R_Earley_Set_Value_Test tests[] = {
+        { -1, -2, taxicab,      -2, 1, -2, taxicab, value2, MARPA_ERR_INVALID_LOCATION },
+        {  0,  0, taxicab, taxicab, 1,  1,      42, value2, MARPA_ERR_INVALID_LOCATION },
+        {  1, -2,      42,      -2, 1, -2,      42, value2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION },
+        {  2, -2,      42,      -2, 1, -2,      42, value2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION },
+      };
 
-  const Marpa_R_Earley_Set_Value_Test tests[] = {
-    { -1, -2, taxicab,      -2, 1, -2, taxicab, value2, MARPA_ERR_INVALID_LOCATION },
-    {  0,  0, taxicab, taxicab, 1,  1,      42, value2, MARPA_ERR_INVALID_LOCATION },
-    {  1, -2,      42,      -2, 1, -2,      42, value2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION },
-    {  2, -2,      42,      -2, 1, -2,      42, value2, MARPA_ERR_NO_EARLEY_SET_AT_LOCATION },
-  };
+      for (ix = 0; ix < sizeof(tests) / sizeof(Marpa_R_Earley_Set_Value_Test); ix++)
+        {
+          const Marpa_R_Earley_Set_Value_Test t = tests[ix];
+          diag("marpa_r_earley_set_value_*() methods, earley_set: %d", t.earley_set);
 
-  for (ix = 0; ix < sizeof(tests) / sizeof(Marpa_R_Earley_Set_Value_Test); ix++)
+          if (t.earley_set == -1 || t.earley_set == 1 || t.earley_set == 2)
+            marpa_m_test("marpa_r_earleme", r, t.earley_set, t.rv_marpa_r_earleme, t.errcode);
+          else
+            marpa_m_test("marpa_r_earleme", r, t.earley_set, t.rv_marpa_r_earleme);
+
+          marpa_m_test("marpa_r_latest_earley_set_value_set", r, taxicab,
+            t.rv_marpa_r_latest_earley_set_value_set);
+          is_int(t.errcode, marpa_g_error(g, NULL),
+            "marpa_r_latest_earley_set_value_set() error code");
+
+          if (t.earley_set == -1 || t.earley_set == 1 || t.earley_set == 2)
+            marpa_m_test("marpa_r_earley_set_value", r,
+              t.earley_set, t.rv_marpa_r_earley_set_value, t.errcode);
+          else
+            marpa_m_test("marpa_r_earley_set_value", r,
+              t.earley_set, t.rv_marpa_r_earley_set_value);
+
+          marpa_m_test("marpa_r_latest_earley_set_values_set", r, 42, &taxicab,
+            t.rv_marpa_r_latest_earley_set_values_set);
+          is_int(t.errcode, marpa_g_error(g, NULL),
+            "marpa_r_latest_earley_set_values_set() error code");
+
+          if (t.earley_set == -1 || t.earley_set == 1 || t.earley_set == 2)
+            marpa_m_test(
+              "marpa_r_earley_set_values", r, t.earley_set, &taxicab, (void **)&value2,
+              t.rv_marpa_r_earley_set_values, t.errcode);
+          else
+            marpa_m_test(
+              "marpa_r_earley_set_values", r, t.earley_set, &taxicab, (void **)&value2,
+              t.rv_marpa_r_earley_set_values);
+
+          is_int ( t.int_p_value_rv_marpa_r_earley_set_values, taxicab,
+            "marpa_r_earley_set_values() int* value" );
+          is_string ( t.void_p_value_rv_marpa_r_earley_set_values, NULL,
+            "marpa_r_earley_set_values() void** value" );
+        }
+    } /* Location Accessors */
+
+    /* Other parse status methods */
     {
-      const Marpa_R_Earley_Set_Value_Test t = tests[ix];
-      diag("marpa_r_earley_set_value_*() methods, earley_set: %d", t.earley_set);
 
-      if (t.earley_set == -1 || t.earley_set == 1 || t.earley_set == 2)
-        marpa_m_test("marpa_r_earleme", r, t.earley_set, t.rv_marpa_r_earleme, t.errcode);
-      else
-        marpa_m_test("marpa_r_earleme", r, t.earley_set, t.rv_marpa_r_earleme);
-
-      marpa_m_test("marpa_r_latest_earley_set_value_set", r, taxicab,
-        t.rv_marpa_r_latest_earley_set_value_set);
-      is_int(t.errcode, marpa_g_error(g, NULL),
-        "marpa_r_latest_earley_set_value_set() error code");
-
-      if (t.earley_set == -1 || t.earley_set == 1 || t.earley_set == 2)
-        marpa_m_test("marpa_r_earley_set_value", r,
-          t.earley_set, t.rv_marpa_r_earley_set_value, t.errcode);
-      else
-        marpa_m_test("marpa_r_earley_set_value", r,
-          t.earley_set, t.rv_marpa_r_earley_set_value);
-
-      marpa_m_test("marpa_r_latest_earley_set_values_set", r, 42, &taxicab,
-        t.rv_marpa_r_latest_earley_set_values_set);
-      is_int(t.errcode, marpa_g_error(g, NULL),
-        "marpa_r_latest_earley_set_values_set() error code");
-
-      if (t.earley_set == -1 || t.earley_set == 1 || t.earley_set == 2)
-        marpa_m_test(
-          "marpa_r_earley_set_values", r, t.earley_set, &taxicab, (void **)&value2,
-          t.rv_marpa_r_earley_set_values, t.errcode);
-      else
-        marpa_m_test(
-          "marpa_r_earley_set_values", r, t.earley_set, &taxicab, (void **)&value2,
-          t.rv_marpa_r_earley_set_values);
-
-      is_int ( t.int_p_value_rv_marpa_r_earley_set_values, taxicab,
-        "marpa_r_earley_set_values() int* value" );
-      is_string ( t.void_p_value_rv_marpa_r_earley_set_values, NULL,
-        "marpa_r_earley_set_values() void** value" );
     }
-
-  /* dumps core unless p_pvalue is set to NULL */
-
-  /* RNS -- the core dump is an application problem.
-   * The "value"
-   * is written to the location pointed to by p_value,
-   * but p_value was not initialized to point to a valid
-   * location in memory.
-   *
-   * Note above -- my parameters to 
-   * marpa_r_earley_set_values() are ADDRESSES of
-   * locations in memory.  That's not the only safe
-   * way to do it, but it is one.
-   */
-  if (0)
-  {
-    int *p_value;
-    void** p_pvalue;
-    marpa_r_earley_set_values(r, 0, p_value, p_pvalue);
-  }
-  if (1)
-  {
-    int value;
-    void* pvalue;
-    marpa_r_earley_set_values(r, 0, &value, &pvalue);
-  }
-
-}
+  } /* recce method tests */
 
   return 0;
 }

--- a/work/dev/marpa.w
+++ b/work/dev/marpa.w
@@ -6246,10 +6246,12 @@ marpa_r_expected_symbol_event_set (Marpa_Recognizer r, Marpa_Symbol_ID xsy_id,
     xsy = XSY_by_ID(xsy_id);
     if (_MARPA_UNLIKELY(XSY_is_Nulling(xsy))) {
       MARPA_ERROR (MARPA_ERR_SYMBOL_IS_NULLING);
+      return -2;
     }
     nsy = NSY_of_XSY(xsy);
     if (_MARPA_UNLIKELY(!nsy)) {
       MARPA_ERROR (MARPA_ERR_SYMBOL_IS_UNUSED);
+      return -2;
     }
     nsyid = ID_of_NSY(nsy);
     if (value) {


### PR DESCRIPTION
Methods from 12.6 added, that seems to be about it for marpa_g_* and marpa_r_*; will be busy at work the next week, hope to proceed with the rest of the methods after next Friday.