### PR TITLE
marpa.w: Explain CIL and CILAR in Abbreviations and vocabulary.

### DIFF
--- a/work/dev/marpa.w
+++ b/work/dev/marpa.w
@@ -441,6 +441,10 @@ very incomplete and possibly obsolete.
 \li alloc: Allocate.
 \li assign: Find something, creating it when necessary.
 \li bv: Bit Vector.
+\li CIL: Constant Integer List,
+a variable-length list of integers,
+which uses AVL's as a memory allocation device.
+\li CILAR: CIL ARena.
 \li cmp: Compare.
 Usually as |_cmp|, the suffix or ``verb" of a function name.
 \li \_Object: As a suffix of a type name, this means an object,


### PR DESCRIPTION
source: https://groups.google.com/d/msg/marpa-parser/LPmHm_JG0m8/O4R2-jQgn2YJ